### PR TITLE
ST-1: Extend spending_transactions table

### DIFF
--- a/app/src/types/database.types.ts
+++ b/app/src/types/database.types.ts
@@ -412,7 +412,10 @@ export type Database = {
           category: string | null
           created_at: string | null
           description: string | null
+          excluded: boolean
+          exclusion_reason: string | null
           id: string
+          merchant: string | null
           transaction_date: string
           updated_at: string | null
           user_card_id: string | null
@@ -423,7 +426,10 @@ export type Database = {
           category?: string | null
           created_at?: string | null
           description?: string | null
+          excluded?: boolean
+          exclusion_reason?: string | null
           id?: string
+          merchant?: string | null
           transaction_date?: string
           updated_at?: string | null
           user_card_id?: string | null
@@ -434,7 +440,10 @@ export type Database = {
           category?: string | null
           created_at?: string | null
           description?: string | null
+          excluded?: boolean
+          exclusion_reason?: string | null
           id?: string
+          merchant?: string | null
           transaction_date?: string
           updated_at?: string | null
           user_card_id?: string | null

--- a/app/supabase/migrations/20260314100000_extend_spending_transactions.sql
+++ b/app/supabase/migrations/20260314100000_extend_spending_transactions.sql
@@ -1,0 +1,45 @@
+-- ST-1: Extend spending_transactions with merchant, excluded, exclusion_reason
+-- and update trigger to exclude flagged transactions from current_spend
+
+-- Add new columns
+ALTER TABLE public.spending_transactions
+  ADD COLUMN IF NOT EXISTS merchant TEXT,
+  ADD COLUMN IF NOT EXISTS excluded BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS exclusion_reason TEXT CHECK (
+    exclusion_reason IS NULL OR
+    exclusion_reason IN ('annual_fee', 'cash_advance', 'bpay', 'balance_transfer', 'other')
+  );
+
+-- Backfill merchant from description for existing rows
+UPDATE public.spending_transactions
+SET merchant = description
+WHERE merchant IS NULL AND description IS NOT NULL;
+
+-- Update the trigger function to exclude rows where excluded = TRUE
+CREATE OR REPLACE FUNCTION update_card_spending()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    UPDATE public.user_cards
+    SET current_spend = (
+      SELECT COALESCE(SUM(amount), 0)
+      FROM public.spending_transactions
+      WHERE user_card_id = NEW.user_card_id
+        AND excluded = FALSE
+    ),
+    spend_updated_at = NOW()
+    WHERE id = NEW.user_card_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.user_cards
+    SET current_spend = (
+      SELECT COALESCE(SUM(amount), 0)
+      FROM public.spending_transactions
+      WHERE user_card_id = OLD.user_card_id
+        AND excluded = FALSE
+    ),
+    spend_updated_at = NOW()
+    WHERE id = OLD.user_card_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- Add `merchant TEXT` column (backfilled from `description`)
- Add `excluded BOOLEAN DEFAULT FALSE` column
- Add `exclusion_reason TEXT` column with CHECK constraint (`annual_fee | cash_advance | bpay | balance_transfer | other`)
- Update `update_card_spending()` trigger to exclude rows where `excluded = TRUE` from `current_spend` calculation
- Update TypeScript types in `database.types.ts`

## Test plan
- [ ] Migration applies idempotently
- [ ] Existing transactions have `merchant` backfilled from `description`
- [ ] `current_spend` on `user_cards` excludes transactions with `excluded = TRUE`
- [ ] TypeScript typecheck passes