### PR TITLE
ST-2: Extend user_cards with tracker fields

### DIFF
--- a/app/src/types/database.types.ts
+++ b/app/src/types/database.types.ts
@@ -461,48 +461,66 @@ export type Database = {
       }
       user_cards: {
         Row: {
+          alert_enabled: boolean
           annual_fee: number | null
           application_date: string | null
           approval_date: string | null
           bank: string | null
+          bonus_earned: boolean
+          bonus_earned_at: string | null
+          bonus_earned_suggested: boolean
+          bonus_spend_deadline: string | null
           cancellation_date: string | null
           card_id: string | null
           created_at: string | null
           current_spend: number | null
           id: string
           name: string | null
+          next_eligible_date: string | null
           notes: string | null
           spend_updated_at: string | null
           status: string | null
           user_id: string
         }
         Insert: {
+          alert_enabled?: boolean
           annual_fee?: number | null
           application_date?: string | null
           approval_date?: string | null
           bank?: string | null
+          bonus_earned?: boolean
+          bonus_earned_at?: string | null
+          bonus_earned_suggested?: boolean
+          bonus_spend_deadline?: string | null
           cancellation_date?: string | null
           card_id?: string | null
           created_at?: string | null
           current_spend?: number | null
           id?: string
           name?: string | null
+          next_eligible_date?: string | null
           notes?: string | null
           spend_updated_at?: string | null
           status?: string | null
           user_id: string
         }
         Update: {
+          alert_enabled?: boolean
           annual_fee?: number | null
           application_date?: string | null
           approval_date?: string | null
           bank?: string | null
+          bonus_earned?: boolean
+          bonus_earned_at?: string | null
+          bonus_earned_suggested?: boolean
+          bonus_spend_deadline?: string | null
           cancellation_date?: string | null
           card_id?: string | null
           created_at?: string | null
           current_spend?: number | null
           id?: string
           name?: string | null
+          next_eligible_date?: string | null
           notes?: string | null
           spend_updated_at?: string | null
           status?: string | null

--- a/app/supabase/migrations/20260314100100_extend_user_cards_tracker.sql
+++ b/app/supabase/migrations/20260314100100_extend_user_cards_tracker.sql
@@ -1,0 +1,19 @@
+-- ST-2: Extend user_cards with spending tracker fields
+
+ALTER TABLE public.user_cards
+  ADD COLUMN IF NOT EXISTS bonus_spend_deadline DATE,
+  ADD COLUMN IF NOT EXISTS alert_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS next_eligible_date DATE,
+  ADD COLUMN IF NOT EXISTS bonus_earned BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS bonus_earned_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS bonus_earned_suggested BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Backfill bonus_spend_deadline for existing rows that have application_date
+-- and are linked to a card with bonus_spend_window_months
+UPDATE public.user_cards uc
+SET bonus_spend_deadline = (uc.application_date + (c.bonus_spend_window_months * INTERVAL '1 month'))::DATE
+FROM public.cards c
+WHERE uc.card_id = c.id
+  AND uc.application_date IS NOT NULL
+  AND c.bonus_spend_window_months IS NOT NULL
+  AND uc.bonus_spend_deadline IS NULL;


### PR DESCRIPTION
## Summary
- Add `bonus_spend_deadline DATE` (computed from `application_date + bonus_spend_window_months`, stored)
- Add `alert_enabled BOOLEAN DEFAULT TRUE`
- Add `next_eligible_date DATE` (set to `cancellation_date + 365d` at cancellation)
- Add `bonus_earned BOOLEAN DEFAULT FALSE`
- Add `bonus_earned_at TIMESTAMPTZ`
- Add `bonus_earned_suggested BOOLEAN DEFAULT FALSE` (system flag for auto-detection)
- Backfill `bonus_spend_deadline` for existing rows with application_date
- Update TypeScript types

## Test plan
- [ ] Migration applies idempotently
- [ ] Existing cards with `application_date` have `bonus_spend_deadline` backfilled
- [ ] TypeScript typecheck passes