### PR TITLE
ST-7: SpendProgressBar + spendPace lib

### DIFF
--- a/app/src/components/tracker/SpendProgressBar.tsx
+++ b/app/src/components/tracker/SpendProgressBar.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { calculatePace, type PaceStatus } from "@/lib/spendPace"
+
+type Props = {
+  currentSpend: number
+  requirement: number
+  applicationDate: string
+  deadline: string
+  variant?: "compact" | "full"
+}
+
+const STATUS_STYLES: Record<PaceStatus, { bar: string; badge: string; label: string }> = {
+  completed: {
+    bar: "bg-[var(--success-fg,#16a34a)]",
+    badge: "bg-[var(--success-bg,#dcfce7)] text-[var(--success-fg,#16a34a)]",
+    label: "Bonus earned!",
+  },
+  on_track: {
+    bar: "bg-[var(--accent)]",
+    badge: "bg-[var(--accent)]/10 text-[var(--accent)]",
+    label: "On track",
+  },
+  behind: {
+    bar: "bg-[var(--warning-fg,#d97706)]",
+    badge: "bg-[var(--warning-bg,#fef3c7)] text-[var(--warning-fg,#d97706)]",
+    label: "Behind pace",
+  },
+  will_miss: {
+    bar: "bg-[var(--danger,#dc2626)]",
+    badge: "bg-[var(--danger)]/10 text-[var(--danger,#dc2626)]",
+    label: "At risk",
+  },
+}
+
+function fmt(n: number) {
+  return n.toLocaleString("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 })
+}
+
+export function SpendProgressBar({ currentSpend, requirement, applicationDate, deadline, variant = "compact" }: Props) {
+  const pace = calculatePace(currentSpend, requirement, applicationDate, deadline)
+  const styles = STATUS_STYLES[pace.paceStatus]
+
+  const progressWidth = `${Math.min(100, pace.percentComplete)}%`
+
+  if (variant === "compact") {
+    return (
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-xs text-[var(--text-secondary)]">
+          <span>
+            {fmt(currentSpend)} <span className="opacity-50">/ {fmt(requirement)}</span>
+          </span>
+          <div className="flex items-center gap-1.5">
+            <span
+              className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${styles.badge}`}
+            >
+              {styles.label}
+            </span>
+            {pace.paceStatus !== "completed" && (
+              <span className="text-[var(--text-secondary)]/70">
+                {pace.daysRemaining}d left
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--surface-strong)]">
+          <div
+            className={`h-full rounded-full transition-all ${styles.bar}`}
+            style={{ width: progressWidth }}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="text-2xl font-bold text-[var(--text-primary)]">
+            {fmt(currentSpend)}
+            <span className="ml-1 text-base font-normal text-[var(--text-secondary)]">
+              / {fmt(requirement)}
+            </span>
+          </p>
+        </div>
+        <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${styles.badge}`}>
+          {styles.label}
+        </span>
+      </div>
+
+      <div className="h-2.5 w-full overflow-hidden rounded-full bg-[var(--surface-strong)]">
+        <div
+          className={`h-full rounded-full transition-all ${styles.bar}`}
+          style={{ width: progressWidth }}
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 rounded-xl border border-[var(--border-default)] bg-[var(--surface-subtle)] p-3 text-center">
+        <div>
+          <p className="text-xs text-[var(--text-secondary)]">Days left</p>
+          <p className="font-semibold text-[var(--text-primary)]">{pace.daysRemaining}</p>
+        </div>
+        <div>
+          <p className="text-xs text-[var(--text-secondary)]">Remaining</p>
+          <p className="font-semibold text-[var(--text-primary)]">
+            {fmt(Math.max(0, requirement - currentSpend))}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-[var(--text-secondary)]">Daily needed</p>
+          <p className="font-semibold text-[var(--text-primary)]">
+            {pace.paceStatus === "completed" ? "—" : fmt(pace.requiredDailySpend)}
+          </p>
+        </div>
+      </div>
+
+      {pace.paceStatus !== "completed" && (
+        <p className="text-xs text-[var(--text-secondary)]">
+          At current pace ({fmt(pace.avgDailySpend)}/day) you&apos;ll reach{" "}
+          <span className="font-medium text-[var(--text-primary)]">
+            {fmt(pace.projectedTotal)}
+          </span>{" "}
+          by the deadline.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/src/lib/spendPace.ts
+++ b/app/src/lib/spendPace.ts
@@ -1,0 +1,63 @@
+export type PaceStatus = 'on_track' | 'behind' | 'will_miss' | 'completed'
+
+export interface PaceCalculation {
+  daysTotal: number
+  daysElapsed: number
+  daysRemaining: number
+  percentComplete: number
+  avgDailySpend: number
+  requiredDailySpend: number
+  projectedTotal: number
+  paceStatus: PaceStatus
+}
+
+export function calculatePace(
+  currentSpend: number,
+  requirement: number,
+  applicationDate: string,
+  deadline: string,
+): PaceCalculation {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const start = new Date(applicationDate)
+  start.setHours(0, 0, 0, 0)
+
+  const end = new Date(deadline)
+  end.setHours(0, 0, 0, 0)
+
+  const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+  const daysTotal = Math.max(1, Math.round((end.getTime() - start.getTime()) / MS_PER_DAY))
+  const daysElapsed = Math.max(1, Math.round((today.getTime() - start.getTime()) / MS_PER_DAY))
+  const daysRemaining = Math.max(0, Math.round((end.getTime() - today.getTime()) / MS_PER_DAY))
+
+  const percentComplete = Math.min(100, (currentSpend / requirement) * 100)
+  const avgDailySpend = daysElapsed > 0 ? currentSpend / daysElapsed : 0
+  const requiredDailySpend = daysRemaining > 0 ? (requirement - currentSpend) / daysRemaining : 0
+  const projectedTotal = avgDailySpend * daysTotal
+
+  let paceStatus: PaceStatus
+  if (currentSpend >= requirement) {
+    paceStatus = 'completed'
+  } else if (daysRemaining === 0) {
+    paceStatus = 'will_miss'
+  } else if (projectedTotal >= requirement) {
+    paceStatus = 'on_track'
+  } else if (projectedTotal >= requirement * 0.8) {
+    paceStatus = 'behind'
+  } else {
+    paceStatus = 'will_miss'
+  }
+
+  return {
+    daysTotal,
+    daysElapsed,
+    daysRemaining,
+    percentComplete,
+    avgDailySpend,
+    requiredDailySpend,
+    projectedTotal,
+    paceStatus,
+  }
+}


### PR DESCRIPTION
## Summary
- `src/lib/spendPace.ts`: pure TS pace calculation (daysTotal, daysElapsed, daysRemaining, percentComplete, avgDailySpend, requiredDailySpend, projectedTotal, paceStatus)
- `src/components/tracker/SpendProgressBar.tsx`: compact + full variants with colour-coded pace status badges and progress bar

## Pace logic
- `completed`: currentSpend >= requirement
- `will_miss`: 0 days remaining (and not completed)
- `on_track`: projectedTotal >= requirement  
- `behind`: projectedTotal >= 80% of requirement
- `will_miss`: otherwise

## Test plan
- [ ] TypeScript typecheck passes
- [ ] Compact variant shows single-line progress bar, days left, status badge
- [ ] Full variant shows pace analysis block with daily needed and projection