### PR TITLE
ST-4: /tracker/[id] — card detail page with transaction entry

### DIFF
--- a/app/src/app/tracker/[id]/page.tsx
+++ b/app/src/app/tracker/[id]/page.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
+import { AppShell } from "@/components/layout/AppShell"
+import { SpendProgressBar } from "@/components/tracker/SpendProgressBar"
+import { TransactionForm } from "@/components/tracker/TransactionForm"
+import { TransactionList } from "@/components/tracker/TransactionList"
+import { supabase } from "@/lib/supabase/client"
+
+type CardDetail = {
+  id: string
+  bank: string | null
+  name: string | null
+  status: string | null
+  current_spend: number | null
+  application_date: string | null
+  bonus_spend_deadline: string | null
+  bonus_earned: boolean
+  user_id: string
+  card: {
+    name: string
+    bank: string
+    bonus_spend_requirement: number | null
+  } | null
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  active: "bg-[var(--success-bg,#dcfce7)] text-[var(--success-fg,#16a34a)]",
+  cancelled: "bg-[var(--surface-strong)] text-[var(--text-secondary)]",
+  pending: "bg-[var(--warning-bg,#fef3c7)] text-[var(--warning-fg,#d97706)]",
+  applied: "bg-[var(--accent)]/10 text-[var(--accent)]",
+}
+
+export default function TrackerDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const id = params?.id as string
+
+  const [card, setCard] = useState<CardDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const loadCard = useCallback(async () => {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) { setLoading(false); return }
+    setUserId(user.id)
+
+    const { data } = await supabase
+      .from("user_cards")
+      .select("id, bank, name, status, current_spend, application_date, bonus_spend_deadline, bonus_earned, user_id, card:cards(name, bank, bonus_spend_requirement)")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single()
+
+    setCard(data as CardDetail | null)
+    setLoading(false)
+  }, [id])
+
+  useEffect(() => {
+    loadCard()
+  }, [loadCard])
+
+  function handleSpendChange() {
+    loadCard()
+    setRefreshKey((k) => k + 1)
+  }
+
+  if (loading) {
+    return (
+      <AppShell>
+        <div className="flex h-48 items-center justify-center text-[var(--text-secondary)]">Loading…</div>
+      </AppShell>
+    )
+  }
+
+  if (!card) {
+    return (
+      <AppShell>
+        <div className="flex h-48 flex-col items-center justify-center gap-3">
+          <p className="text-[var(--text-secondary)]">Card not found.</p>
+          <button onClick={() => router.push("/tracker")} className="text-sm text-[var(--accent)] underline">
+            Back to tracker
+          </button>
+        </div>
+      </AppShell>
+    )
+  }
+
+  const cardName = card.name ?? card.card?.name ?? "Card"
+  const bank = card.bank ?? card.card?.bank ?? ""
+  const requirement = card.card?.bonus_spend_requirement ?? 0
+  const statusKey = card.status ?? "active"
+  const badgeClass = STATUS_BADGE[statusKey] ?? STATUS_BADGE.active
+
+  return (
+    <AppShell>
+      <div className="space-y-5">
+        {/* Back button */}
+        <button
+          onClick={() => router.push("/tracker")}
+          className="flex items-center gap-1.5 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to tracker
+        </button>
+
+        {/* Card header */}
+        <div className="flex items-start justify-between rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4">
+          <div>
+            <p className="text-lg font-bold text-[var(--text-primary)]">{cardName}</p>
+            <p className="text-sm text-[var(--text-secondary)]">{bank}</p>
+          </div>
+          <span className={`rounded-full px-2.5 py-1 text-xs font-semibold capitalize ${badgeClass}`}>
+            {statusKey}
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        {card.application_date && card.bonus_spend_deadline && requirement > 0 && (
+          <div className="rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4">
+            <SpendProgressBar
+              currentSpend={card.current_spend ?? 0}
+              requirement={requirement}
+              applicationDate={card.application_date}
+              deadline={card.bonus_spend_deadline}
+              variant="full"
+            />
+          </div>
+        )}
+
+        {/* Add Transaction */}
+        {userId && (
+          <div className="rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4">
+            <h2 className="mb-3 font-semibold text-[var(--text-primary)]">Add Transaction</h2>
+            <TransactionForm
+              userCardId={card.id}
+              userId={userId}
+              onSuccess={handleSpendChange}
+            />
+          </div>
+        )}
+
+        {/* Transaction history */}
+        <div className="rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4">
+          <h2 className="mb-3 font-semibold text-[var(--text-primary)]">Transaction History</h2>
+          <TransactionList
+            key={refreshKey}
+            userCardId={card.id}
+            onSpendChange={handleSpendChange}
+          />
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/app/src/components/tracker/TransactionForm.tsx
+++ b/app/src/components/tracker/TransactionForm.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import { supabase } from "@/lib/supabase/client"
+
+const EXCLUSION_REASONS = [
+  { value: "annual_fee", label: "Annual fee" },
+  { value: "cash_advance", label: "Cash advance" },
+  { value: "bpay", label: "BPAY" },
+  { value: "balance_transfer", label: "Balance transfer" },
+  { value: "other", label: "Other" },
+]
+
+type Props = {
+  userCardId: string
+  userId: string
+  onSuccess: () => void
+}
+
+function todayISO() {
+  return new Date().toISOString().split("T")[0]
+}
+
+export function TransactionForm({ userCardId, userId, onSuccess }: Props) {
+  const [date, setDate] = useState(todayISO())
+  const [merchant, setMerchant] = useState("")
+  const [amount, setAmount] = useState("")
+  const [excluded, setExcluded] = useState(false)
+  const [exclusionReason, setExclusionReason] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const parsedAmount = parseFloat(amount)
+    if (!merchant.trim() || isNaN(parsedAmount) || parsedAmount <= 0) {
+      toast.error("Please fill in all required fields with valid values.")
+      return
+    }
+    if (excluded && !exclusionReason) {
+      toast.error("Please select an exclusion reason.")
+      return
+    }
+
+    setSubmitting(true)
+    const { error } = await supabase.from("spending_transactions").insert({
+      user_card_id: userCardId,
+      user_id: userId,
+      transaction_date: date,
+      merchant: merchant.trim(),
+      amount: parsedAmount,
+      description: merchant.trim(),
+      excluded,
+      exclusion_reason: excluded ? exclusionReason : null,
+    })
+    setSubmitting(false)
+
+    if (error) {
+      toast.error("Failed to add transaction")
+      return
+    }
+
+    toast.success("Transaction added")
+    setDate(todayISO())
+    setMerchant("")
+    setAmount("")
+    setExcluded(false)
+    setExclusionReason("")
+    onSuccess()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">Date</label>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            required
+            className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">
+            Merchant <span className="text-[var(--danger,#dc2626)]">*</span>
+          </label>
+          <input
+            type="text"
+            value={merchant}
+            onChange={(e) => setMerchant(e.target.value)}
+            placeholder="e.g. Woolworths"
+            required
+            className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">
+            Amount (AUD) <span className="text-[var(--danger,#dc2626)]">*</span>
+          </label>
+          <input
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder="0.00"
+            min="0.01"
+            step="0.01"
+            required
+            className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-[var(--text-secondary)]">
+          <input
+            type="checkbox"
+            checked={excluded}
+            onChange={(e) => {
+              setExcluded(e.target.checked)
+              if (!e.target.checked) setExclusionReason("")
+            }}
+            className="rounded border-[var(--border-default)]"
+          />
+          Exclude from min-spend
+        </label>
+
+        {excluded && (
+          <select
+            value={exclusionReason}
+            onChange={(e) => setExclusionReason(e.target.value)}
+            required={excluded}
+            className="rounded-lg border border-[var(--border-default)] bg-[var(--surface)] px-3 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+          >
+            <option value="">Select reason…</option>
+            {EXCLUSION_REASONS.map((r) => (
+              <option key={r.value} value={r.value}>{r.label}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="rounded-lg px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-50"
+        style={{ background: "var(--gradient-cta)" }}
+      >
+        {submitting ? "Adding…" : "Add transaction"}
+      </button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- New route `/tracker/[id]` (id = `user_cards.id`)
- Card header: bank + name + status badge
- Full `SpendProgressBar` variant showing pace analysis block
- `TransactionForm`: date (default today), merchant (required), amount (required), excluded checkbox, exclusion reason (conditional select)
- `TransactionList` embedded with spend refresh on change
- Back button to `/tracker`

## Test plan
- [ ] Page loads correct card for authenticated user
- [ ] 404-like state shown for unknown card ID
- [ ] SpendProgressBar shows full variant with pace stats
- [ ] TransactionForm adds transaction, reloads card spend and transaction list
- [ ] Excluded transactions show reason label in list