### PR TITLE
ST-8: Spending tracker cron — pace alerts, deadline warnings, completion handler

### DIFF
--- a/app/src/app/api/cron/spending-alerts/route.ts
+++ b/app/src/app/api/cron/spending-alerts/route.ts
@@ -1,0 +1,184 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { resend, FROM_EMAIL, APP_URL } from '@/lib/email/client'
+import { calculatePace } from '@/lib/spendPace'
+import {
+  getPaceAlertEmail,
+  get14DayWarningEmail,
+  get3DayWarningEmail,
+  getCompletionEmail,
+} from '@/lib/email/spendingAlertTemplates'
+
+export const dynamic = 'force-dynamic'
+
+type AlertType = 'spending_pace' | 'spending_14day' | 'spending_3day' | 'spending_completion'
+
+type CardRow = {
+  id: string
+  user_id: string
+  bank: string | null
+  name: string | null
+  current_spend: number | null
+  bonus_spend_deadline: string | null
+  application_date: string | null
+  alert_enabled: boolean
+  bonus_earned: boolean
+  card: {
+    bonus_spend_requirement: number | null
+    welcome_bonus_points: number | null
+    points_currency: string | null
+  } | null
+}
+
+export async function GET(request: Request) {
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_KEY!,
+  )
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const todayStr = today.toISOString().split('T')[0]
+
+    const { data: activeCards, error } = await supabaseAdmin
+      .from('user_cards')
+      .select(`
+        id, user_id, bank, name, current_spend, bonus_spend_deadline,
+        application_date, alert_enabled, bonus_earned,
+        card:cards!card_id(bonus_spend_requirement, welcome_bonus_points, points_currency)
+      `)
+      .eq('status', 'active')
+      .eq('alert_enabled', true)
+      .eq('bonus_earned', false)
+      .not('bonus_spend_deadline', 'is', null)
+      .gte('bonus_spend_deadline', todayStr)
+
+    if (error) throw error
+
+    const stats = { pace: 0, warning14: 0, warning3: 0, completion: 0, skipped: 0 }
+
+    const promises = ((activeCards ?? []) as unknown as CardRow[]).map((card) =>
+      (async () => {
+        const requirement = card.card?.bonus_spend_requirement ?? 0
+        if (requirement === 0) {
+          stats.skipped++
+          return
+        }
+
+        const currentSpend = card.current_spend ?? 0
+        const deadline = card.bonus_spend_deadline!
+        const applicationDate = card.application_date ?? todayStr
+
+        const pace = calculatePace(currentSpend, requirement, applicationDate, deadline)
+        const { daysRemaining, requiredDailySpend, paceStatus } = pace
+
+        let alertType: AlertType | null = null
+        if (currentSpend >= requirement) {
+          alertType = 'spending_completion'
+        } else if (daysRemaining <= 3 && paceStatus === 'will_miss') {
+          alertType = 'spending_3day'
+        } else if (daysRemaining <= 14 && paceStatus !== 'on_track') {
+          alertType = 'spending_14day'
+        } else if (paceStatus === 'will_miss' && daysRemaining > 14) {
+          alertType = 'spending_pace'
+        }
+
+        if (!alertType) {
+          stats.skipped++
+          return
+        }
+
+        // Deduplicate: skip if same alert type already sent today
+        const { data: existing } = await supabaseAdmin
+          .from('email_reminders')
+          .select('id')
+          .eq('user_card_id', card.id)
+          .eq('reminder_type', alertType)
+          .gte('sent_at', todayStr)
+          .maybeSingle()
+
+        if (existing) {
+          stats.skipped++
+          return
+        }
+
+        const { data: userData } = await supabaseAdmin.auth.admin.getUserById(card.user_id)
+        if (!userData?.user?.email) {
+          stats.skipped++
+          return
+        }
+
+        const emailData = {
+          cardName: card.name ?? '',
+          bank: card.bank ?? '',
+          currentSpend,
+          requirement,
+          daysRemaining,
+          dailyNeeded: requiredDailySpend,
+          deadline: new Date(deadline).toLocaleDateString('en-AU', {
+            day: '2-digit',
+            month: 'long',
+            year: 'numeric',
+          }),
+          appUrl: APP_URL,
+        }
+
+        const emailFns = {
+          spending_completion: getCompletionEmail,
+          spending_3day: get3DayWarningEmail,
+          spending_14day: get14DayWarningEmail,
+          spending_pace: getPaceAlertEmail,
+        }
+        const email = emailFns[alertType](emailData)
+
+        await resend.emails.send({
+          from: FROM_EMAIL,
+          to: userData.user.email,
+          subject: email.subject,
+          html: email.html,
+          text: email.text,
+        })
+
+        await supabaseAdmin.from('email_reminders').insert({
+          user_card_id: card.id,
+          reminder_type: alertType,
+          email_to: userData.user.email,
+        })
+
+        if (alertType === 'spending_completion') {
+          await supabaseAdmin
+            .from('user_cards')
+            .update({ bonus_earned_suggested: true })
+            .eq('id', card.id)
+          stats.completion++
+        } else if (alertType === 'spending_3day') {
+          stats.warning3++
+        } else if (alertType === 'spending_14day') {
+          stats.warning14++
+        } else {
+          stats.pace++
+        }
+      })()
+    )
+
+    await Promise.all(promises)
+
+    return NextResponse.json({
+      success: true,
+      stats,
+      totalCards: activeCards?.length ?? 0,
+    })
+  } catch (err: unknown) {
+    console.error('spending-alerts cron error:', err)
+    return NextResponse.json(
+      { error: (err as Error).message ?? 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/src/lib/email/spendingAlertTemplates.ts
+++ b/app/src/lib/email/spendingAlertTemplates.ts
@@ -1,0 +1,107 @@
+interface SpendAlertData {
+  cardName: string
+  bank: string
+  currentSpend: number
+  requirement: number
+  daysRemaining: number
+  dailyNeeded: number
+  deadline: string
+  appUrl: string
+}
+
+function fmtCurrency(n: number) {
+  return `$${n.toLocaleString("en-AU", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+}
+
+function progressBar(current: number, target: number) {
+  const pct = Math.min(100, Math.round((current / target) * 100))
+  return `
+    <div style="background:#e2e8f0;height:10px;border-radius:5px;overflow:hidden;margin:12px 0;">
+      <div style="background:linear-gradient(90deg,#10b981 0%,#059669 100%);height:100%;width:${pct}%;"></div>
+    </div>
+    <p style="font-size:13px;color:#718096;margin:0;">${fmtCurrency(current)} of ${fmtCurrency(target)} (${pct}%)</p>
+  `
+}
+
+export function getPaceAlertEmail(data: SpendAlertData) {
+  const remaining = data.requirement - data.currentSpend
+  return {
+    subject: `Pace alert: ${data.bank} ${data.cardName} is off track`,
+    html: `
+      <!DOCTYPE html><html><head><meta charset="utf-8"></head>
+      <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#333;max-width:600px;margin:0 auto;padding:20px;">
+        <div style="background:linear-gradient(135deg,#f59e0b 0%,#d97706 100%);padding:28px;border-radius:10px;text-align:center;margin-bottom:24px;">
+          <h1 style="color:white;margin:0;font-size:22px;">Pace Alert</h1>
+        </div>
+        <p>Your <strong>${data.bank} ${data.cardName}</strong> bonus spend is not on track to be completed before the deadline.</p>
+        ${progressBar(data.currentSpend, data.requirement)}
+        <div style="background:#fef3c7;border:1px solid #fde68a;padding:16px;border-radius:8px;margin:16px 0;">
+          <p style="margin:0;font-size:15px;">You need to spend <strong>${fmtCurrency(data.dailyNeeded)}/day</strong> for the next <strong>${data.daysRemaining} days</strong> to reach ${fmtCurrency(data.requirement)} by ${data.deadline}.</p>
+        </div>
+        <a href="${data.appUrl}/tracker" style="display:inline-block;background:linear-gradient(135deg,#10b981 0%,#059669 100%);color:white;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;">View Tracker</a>
+      </body></html>
+    `,
+    text: `Pace alert: ${data.bank} ${data.cardName} is off track. You've spent ${fmtCurrency(data.currentSpend)} of ${fmtCurrency(data.requirement)}. You need ${fmtCurrency(data.dailyNeeded)}/day for the next ${data.daysRemaining} days. Visit ${data.appUrl}/tracker`,
+  }
+}
+
+export function get14DayWarningEmail(data: SpendAlertData) {
+  const remaining = data.requirement - data.currentSpend
+  return {
+    subject: `14 days left: ${data.bank} ${data.cardName} spend deadline`,
+    html: `
+      <!DOCTYPE html><html><head><meta charset="utf-8"></head>
+      <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#333;max-width:600px;margin:0 auto;padding:20px;">
+        <div style="background:linear-gradient(135deg,#f59e0b 0%,#d97706 100%);padding:28px;border-radius:10px;text-align:center;margin-bottom:24px;">
+          <h1 style="color:white;margin:0;font-size:22px;">14 Days to Go</h1>
+        </div>
+        <p>Your <strong>${data.bank} ${data.cardName}</strong> bonus spend deadline is in <strong>14 days</strong> (${data.deadline}).</p>
+        ${progressBar(data.currentSpend, data.requirement)}
+        <p>You still need <strong>${fmtCurrency(remaining)}</strong>. That's <strong>${fmtCurrency(data.dailyNeeded)}/day</strong> to stay on track.</p>
+        <a href="${data.appUrl}/tracker" style="display:inline-block;background:linear-gradient(135deg,#10b981 0%,#059669 100%);color:white;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;">View Tracker</a>
+      </body></html>
+    `,
+    text: `14 days to go: ${data.bank} ${data.cardName} deadline is ${data.deadline}. ${fmtCurrency(remaining)} still needed. Visit ${data.appUrl}/tracker`,
+  }
+}
+
+export function get3DayWarningEmail(data: SpendAlertData) {
+  const remaining = data.requirement - data.currentSpend
+  return {
+    subject: `FINAL WARNING: ${data.bank} ${data.cardName} spend due in 3 days`,
+    html: `
+      <!DOCTYPE html><html><head><meta charset="utf-8"></head>
+      <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#333;max-width:600px;margin:0 auto;padding:20px;">
+        <div style="background:linear-gradient(135deg,#dc2626 0%,#b91c1c 100%);padding:28px;border-radius:10px;text-align:center;margin-bottom:24px;">
+          <h1 style="color:white;margin:0;font-size:22px;">Final Warning — 3 Days Left</h1>
+        </div>
+        <p style="font-size:16px;">Your <strong>${data.bank} ${data.cardName}</strong> bonus spend deadline is in <strong>3 days</strong> (${data.deadline}).</p>
+        ${progressBar(data.currentSpend, data.requirement)}
+        <div style="background:#fee2e2;border:1px solid #fca5a5;padding:16px;border-radius:8px;margin:16px 0;">
+          <p style="margin:0;font-size:15px;font-weight:600;color:#dc2626;">You need to spend ${fmtCurrency(remaining)} in the next 3 days to earn the bonus.</p>
+        </div>
+        <a href="${data.appUrl}/tracker" style="display:inline-block;background:linear-gradient(135deg,#dc2626 0%,#b91c1c 100%);color:white;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;">View Tracker Now</a>
+      </body></html>
+    `,
+    text: `FINAL WARNING: ${data.bank} ${data.cardName} deadline ${data.deadline}. ${fmtCurrency(remaining)} needed in 3 days. Visit ${data.appUrl}/tracker`,
+  }
+}
+
+export function getCompletionEmail(data: SpendAlertData) {
+  return {
+    subject: `Bonus spend complete: ${data.bank} ${data.cardName}`,
+    html: `
+      <!DOCTYPE html><html><head><meta charset="utf-8"></head>
+      <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#333;max-width:600px;margin:0 auto;padding:20px;">
+        <div style="background:linear-gradient(135deg,#10b981 0%,#059669 100%);padding:28px;border-radius:10px;text-align:center;margin-bottom:24px;">
+          <h1 style="color:white;margin:0;font-size:22px;">Bonus Spend Complete!</h1>
+        </div>
+        <p style="font-size:16px;">Congratulations! You've met the minimum spend requirement for <strong>${data.bank} ${data.cardName}</strong>.</p>
+        ${progressBar(data.currentSpend, data.requirement)}
+        <p>You should receive your welcome bonus points within the timeframe stated in your card terms. Check your account to confirm receipt.</p>
+        <a href="${data.appUrl}/tracker" style="display:inline-block;background:linear-gradient(135deg,#10b981 0%,#059669 100%);color:white;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;">View Tracker</a>
+      </body></html>
+    `,
+    text: `Bonus spend complete! ${data.bank} ${data.cardName} requirement of ${fmtCurrency(data.requirement)} met. Visit ${data.appUrl}/tracker`,
+  }
+}

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -3,5 +3,8 @@
     "deploymentEnabled": false
   },
   "buildCommand": "pnpm run build",
-  "installCommand": "rm -rf node_modules && pnpm install --force"
+  "installCommand": "rm -rf node_modules && pnpm install --force",
+  "crons": [
+    { "path": "/api/cron/spending-alerts", "schedule": "0 22 * * *" }
+  ]
 }


### PR DESCRIPTION
closes #24

## Summary
- `app/src/app/api/cron/spending-alerts/route.ts` — daily cron handler (08:00 AEST / 22:00 UTC)
- `app/src/lib/email/spendingAlertTemplates.ts` — email templates for all 4 alert types
- `app/vercel.json` — adds Vercel cron schedule entry

## Alert logic
| Alert | Condition |
|-------|-----------|
| Pace alert | `will_miss` + >14 days remaining |
| 14-day warning | `daysRemaining <= 14` + not `on_track` |
| 3-day final warning | `daysRemaining <= 3` + `will_miss` |
| Completion | `current_spend >= requirement` |

On completion, sets `bonus_earned_suggested = true`. Deduplicates via `email_reminders` (one alert type per card per day). Cards with `alert_enabled = false` are skipped.