### PR TITLE
CI-5: /inquiries page — Pro cadence recommendations grid

### DIFF
--- a/app/src/app/inquiries/page.tsx
+++ b/app/src/app/inquiries/page.tsx
@@ -17,9 +17,11 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { supabase } from "@/lib/supabase/client"
+import { CadenceAdvisor } from "@/components/inquiries/CadenceAdvisor"
 import type { Database } from "@/types/database.types"
 
 type CreditInquiry = Database["public"]["Tables"]["credit_inquiries"]["Row"]
+type BankRule = Database["public"]["Tables"]["bank_rules"]["Row"]
 
 type OutcomeType = "approved" | "declined" | "pending" | "withdrawn"
 
@@ -63,6 +65,7 @@ const DEFAULT_FORM = {
 export default function InquiriesPage() {
   const router = useRouter()
   const [inquiries, setInquiries] = useState<CreditInquiry[]>([])
+  const [bankRules, setBankRules] = useState<BankRule[]>([])
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [form, setForm] = useState(DEFAULT_FORM)
@@ -79,16 +82,24 @@ export default function InquiriesPage() {
       return
     }
 
-    const { data, error } = await supabase
-      .from("credit_inquiries")
-      .select("*")
-      .order("application_date", { ascending: false })
+    const [inquiriesResult, rulesResult] = await Promise.all([
+      supabase
+        .from("credit_inquiries")
+        .select("*")
+        .order("application_date", { ascending: false }),
+      supabase.from("bank_rules").select("*").order("bank"),
+    ])
 
-    if (error) {
-      toast.error(error.message || "Unable to load inquiries")
+    if (inquiriesResult.error) {
+      toast.error(inquiriesResult.error.message || "Unable to load inquiries")
     } else {
-      setInquiries(data ?? [])
+      setInquiries(inquiriesResult.data ?? [])
     }
+
+    if (!rulesResult.error) {
+      setBankRules(rulesResult.data ?? [])
+    }
+
     setLoading(false)
   }
 
@@ -543,6 +554,15 @@ export default function InquiriesPage() {
             )}
           </CardContent>
         </Card>
+
+        {/* Safe Cadence Advisor — Pro feature */}
+        {bankRules.length > 0 && (
+          <CadenceAdvisor
+            inquiries={inquiries}
+            bankRules={bankRules}
+            isPro={false}
+          />
+        )}
       </div>
     </AppShell>
   )

--- a/app/src/components/inquiries/CadenceAdvisor.tsx
+++ b/app/src/components/inquiries/CadenceAdvisor.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import { useMemo } from "react"
+import { format, addMonths } from "date-fns"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ProGate } from "@/components/ui/ProGate"
+import { getCadenceSignal } from "@/components/inquiries/CadenceSignal"
+import type { Database } from "@/types/database.types"
+
+type CreditInquiry = Database["public"]["Tables"]["credit_inquiries"]["Row"]
+type BankRule = Database["public"]["Tables"]["bank_rules"]["Row"]
+
+interface CadenceAdvisorProps {
+  inquiries: CreditInquiry[]
+  bankRules: BankRule[]
+  isPro?: boolean
+}
+
+interface BankSummary {
+  bank: string
+  status: "safe" | "caution" | "blocked"
+  lastApprovalDate: string | null
+  monthsAgo: number | null
+  nextSafeDate: string | null
+  monthsRemaining: number | null
+  ruleMonths: number
+  ruleDescription: string
+  sourceUrl: string | null
+}
+
+export function CadenceAdvisor({ inquiries, bankRules, isPro = false }: CadenceAdvisorProps) {
+  const bankSummaries = useMemo<BankSummary[]>(() => {
+    return bankRules.map((rule) => {
+      const signal = getCadenceSignal(rule.bank, inquiries, bankRules)
+
+      const approvedForBank = inquiries
+        .filter((i) => i.bank === rule.bank && i.outcome === "approved")
+        .sort(
+          (a, b) =>
+            new Date(b.application_date).getTime() -
+            new Date(a.application_date).getTime()
+        )
+      const lastApproval = approvedForBank[0]
+
+      let lastApprovalDate: string | null = null
+      let monthsAgo: number | null = null
+      let nextSafeDate: string | null = null
+
+      if (lastApproval) {
+        const d = new Date(lastApproval.application_date)
+        const now = new Date()
+        lastApprovalDate = format(d, "MMM yyyy")
+        monthsAgo = Math.floor(
+          (now.getTime() - d.getTime()) / (1000 * 60 * 60 * 24 * 30.44)
+        )
+        if (signal.monthsRemaining && signal.monthsRemaining > 0) {
+          nextSafeDate = format(addMonths(d, rule.rule_months), "dd MMM yyyy")
+        }
+      }
+
+      return {
+        bank: rule.bank,
+        status: signal.status,
+        lastApprovalDate,
+        monthsAgo,
+        nextSafeDate,
+        monthsRemaining: signal.monthsRemaining ?? null,
+        ruleMonths: rule.rule_months,
+        ruleDescription: rule.rule_description,
+        sourceUrl: rule.source_url ?? null,
+      }
+    })
+  }, [bankRules, inquiries])
+
+  const openBanks = bankSummaries.filter((b) => b.status === "safe")
+  const blockedBanks = bankSummaries.filter(
+    (b) => b.status === "blocked" || b.status === "caution"
+  )
+
+  // Sorted: blocked first (most months remaining), then caution, then safe
+  const sortedSummaries = [...bankSummaries].sort((a, b) => {
+    const order = { blocked: 0, caution: 1, safe: 2 }
+    if (order[a.status] !== order[b.status]) return order[a.status] - order[b.status]
+    if (a.monthsRemaining !== null && b.monthsRemaining !== null) {
+      return b.monthsRemaining - a.monthsRemaining
+    }
+    return a.bank.localeCompare(b.bank)
+  })
+
+  const statusConfig = {
+    safe: { emoji: "🟢", label: "Open", textClass: "text-emerald-700 dark:text-emerald-400" },
+    caution: { emoji: "🟡", label: "Soon", textClass: "text-amber-700 dark:text-amber-400" },
+    blocked: { emoji: "🔴", label: "Wait", textClass: "text-red-700 dark:text-red-400" },
+  }
+
+  const summaryLine = (
+    <div className="mb-4 flex flex-wrap gap-4">
+      <div className="flex items-center gap-1.5 text-sm">
+        <span className="text-base">🟢</span>
+        <span className="font-semibold text-emerald-700 dark:text-emerald-400">
+          {openBanks.length} bank{openBanks.length !== 1 ? "s" : ""} open now
+        </span>
+        {openBanks.length > 0 && (
+          <span className="text-[var(--text-secondary)]">
+            ({openBanks.map((b) => b.bank).join(", ")})
+          </span>
+        )}
+      </div>
+      {blockedBanks.length > 0 && (
+        <div className="flex items-center gap-1.5 text-sm">
+          <span className="text-base">🔴</span>
+          <span className="font-semibold text-red-700 dark:text-red-400">
+            {blockedBanks.length} blocked
+          </span>
+          <span className="text-[var(--text-secondary)]">
+            (
+            {blockedBanks
+              .map((b) => `${b.bank}${b.monthsRemaining ? ` — ${b.monthsRemaining}mo` : ""}`)
+              .join(", ")}
+            )
+          </span>
+        </div>
+      )}
+    </div>
+  )
+
+  const fullGrid = (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[var(--border-default)] bg-[var(--surface-muted)]">
+            <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-secondary)]">
+              Bank
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-secondary)]">
+              Status
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-secondary)]">
+              Last approval
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-secondary)]">
+              Next eligible
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-secondary)]">
+              Rule
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--border-default)]">
+          {sortedSummaries.map((b) => {
+            const cfg = statusConfig[b.status]
+            return (
+              <tr
+                key={b.bank}
+                className="transition-colors hover:bg-[var(--surface-subtle)]"
+              >
+                <td className="px-4 py-3 font-medium text-[var(--text-primary)]">
+                  {b.bank}
+                </td>
+                <td className={`px-4 py-3 font-medium ${cfg.textClass}`}>
+                  {cfg.emoji} {cfg.label}
+                </td>
+                <td className="px-4 py-3 text-[var(--text-secondary)]">
+                  {b.lastApprovalDate
+                    ? `${b.lastApprovalDate} (${b.monthsAgo}mo ago)`
+                    : "Never"}
+                </td>
+                <td className="px-4 py-3 text-[var(--text-secondary)]">
+                  {b.nextSafeDate ?? "—"}
+                </td>
+                <td className="px-4 py-3 text-xs text-[var(--text-secondary)]">
+                  {b.sourceUrl ? (
+                    <a
+                      href={b.sourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-[var(--accent)]"
+                    >
+                      {b.ruleMonths}mo rule
+                    </a>
+                  ) : (
+                    `${b.ruleMonths}mo rule`
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+
+  return (
+    <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
+      <CardHeader className="border-b border-[var(--border-default)]">
+        <CardTitle className="text-[var(--text-primary)]">Safe Cadence Advisor</CardTitle>
+        <p className="text-xs text-[var(--text-secondary)]">
+          Per-bank eligibility based on your approval history
+        </p>
+      </CardHeader>
+      <CardContent className="pt-5">
+        {summaryLine}
+
+        <ProGate
+          isPro={isPro}
+          feature="cadence recommendations"
+          previewRows={3}
+        >
+          {fullGrid}
+        </ProGate>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/src/components/ui/ProGate.tsx
+++ b/app/src/components/ui/ProGate.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { Lock } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface ProGateProps {
+  feature?: string
+  children: React.ReactNode
+  isPro?: boolean
+  previewRows?: number
+}
+
+export function ProGate({ feature, children, isPro = false, previewRows }: ProGateProps) {
+  if (isPro) {
+    return <>{children}</>
+  }
+
+  return (
+    <div className="relative">
+      {/* Blurred preview */}
+      <div
+        className="pointer-events-none select-none overflow-hidden"
+        style={{
+          maxHeight: previewRows ? `${previewRows * 48}px` : undefined,
+          WebkitMaskImage: "linear-gradient(to bottom, black 40%, transparent 100%)",
+          maskImage: "linear-gradient(to bottom, black 40%, transparent 100%)",
+        }}
+        aria-hidden
+      >
+        <div className="blur-sm opacity-40">{children}</div>
+      </div>
+
+      {/* Lock overlay */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 rounded-xl bg-[var(--surface)]/60 backdrop-blur-sm">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--surface-strong)]">
+          <Lock className="h-5 w-5 text-[var(--accent)]" />
+        </div>
+        <div className="text-center">
+          <p className="text-sm font-semibold text-[var(--text-primary)]">Pro feature</p>
+          {feature && (
+            <p className="mt-0.5 text-xs text-[var(--text-secondary)]">{feature}</p>
+          )}
+        </div>
+        <Button
+          size="sm"
+          className="mt-1 text-white shadow-sm"
+          style={{ background: "var(--gradient-cta)" }}
+          onClick={() => window.location.href = "/settings#upgrade"}
+        >
+          Upgrade to Pro
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
closes #34

## Summary
- New `CadenceAdvisor` component renders full per-bank status grid on `/inquiries`
- Sorted: blocked (most months remaining) → caution → safe
- Each row shows: bank, status emoji, last approval date+months ago, next eligible date, rule source link
- Summary counts (open/blocked) always visible to free users
- Full grid gated behind new `ProGate` component with blur overlay
- `ProGate` component added at `app/src/components/ui/ProGate.tsx` for reuse
- `/inquiries` page now loads `bank_rules` in parallel with `credit_inquiries`