### PR TITLE
AF-3: Balance progress bar + "almost there" calculation

### DIFF
--- a/app/src/components/flights/RedemptionProgress.tsx
+++ b/app/src/components/flights/RedemptionProgress.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+interface RedemptionProgressProps {
+  userBalance: number
+  pointsRequired: number
+  program: 'qff' | 'velocity'
+}
+
+export function RedemptionProgress({ userBalance, pointsRequired, program }: RedemptionProgressProps) {
+  const percentage = Math.min(100, Math.round((userBalance / pointsRequired) * 100))
+  const canBook = userBalance >= pointsRequired
+  const pointsNeeded = Math.max(0, pointsRequired - userBalance)
+  const almostThere = percentage >= 70 && !canBook
+
+  const programLabel = program === 'qff' ? 'QFF' : 'Velocity'
+
+  if (canBook) {
+    return (
+      <div className="space-y-1">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--success-bg)]">
+          <div className="h-2 w-full rounded-full bg-green-500" />
+        </div>
+        <p className="text-xs font-medium text-green-600">Ready to book</p>
+        <p className="text-xs text-[var(--text-secondary)]">
+          {userBalance.toLocaleString()} / {pointsRequired.toLocaleString()} pts
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--surface-strong)]">
+        <div
+          className="h-2 rounded-full transition-all"
+          style={{
+            width: `${percentage}%`,
+            backgroundColor: almostThere ? 'rgb(251 191 36)' : 'var(--accent)',
+          }}
+        />
+      </div>
+      <p className="text-xs text-[var(--text-secondary)]">
+        {almostThere
+          ? `Almost there — ${pointsNeeded.toLocaleString()} ${programLabel} pts to go`
+          : `${pointsNeeded.toLocaleString()} ${programLabel} pts to go`}
+      </p>
+      <p className="text-xs text-[var(--text-secondary)]">
+        {userBalance.toLocaleString()} / {pointsRequired.toLocaleString()} pts
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `RedemptionProgress` component at `app/src/components/flights/RedemptionProgress.tsx`
- Three visual states based on `userBalance / pointsRequired` ratio:
  - **Ready to book** (100%+): full green bar
  - **Almost there** (70–99%): amber bar with points-to-go label
  - **Far** (<70%): accent blue bar with points-to-go label
- Progress bar width driven by inline style for precise percentage rendering
- Used by the /flights page (AF-2) to surface "Almost there" routes in a dedicated section above the full grid

## Test plan
- [ ] Component renders all three states correctly
- [ ] Progress bar width matches percentage value
- [ ] Can-book state shows green bar and "Ready to book" label
- [ ] Almost-there (70–99%) shows amber bar and "Almost there — X pts to go"
- [ ] Far state (<70%) shows accent bar and "X pts to go"
- [ ] Points shown as `userBalance / pointsRequired pts`
- [ ] `pointsNeeded` calculation is correct (`max(0, required - balance)`)

closes #41