### PR TITLE
AF-4: Amex MR transfer partner routes

### DIFF
--- a/app/src/app/flights/page.tsx
+++ b/app/src/app/flights/page.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/select'
 import { RedemptionProgress } from '@/components/flights/RedemptionProgress'
 import { supabase } from '@/lib/supabase/client'
+import { calculateEffectiveBalance, type TransferPartner } from '@/lib/transferPartners'
 
 interface LoyaltyBalance {
   id: string
@@ -46,6 +47,8 @@ interface RouteWithBalance extends AwardFlightRoute {
   percentage: number
   canBook: boolean
   almostThere: boolean
+  transferredPoints: number
+  bookableViaTransfer: boolean
 }
 
 type ProgramFilter = 'all' | 'qff' | 'velocity'
@@ -71,9 +74,11 @@ const PROGRAM_LABELS: Record<string, string> = {
 
 export default function FlightsPage() {
   const router = useRouter()
-  const [routes, setRoutes] = useState<RouteWithBalance[]>([])
+  const [routes, setRoutes] = useState<AwardFlightRoute[]>([])
+  const [balanceMap, setBalanceMap] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(true)
   const [hasBalances, setHasBalances] = useState(false)
+  const [includeAmexTransfers, setIncludeAmexTransfers] = useState(false)
 
   const [programFilter, setProgramFilter] = useState<ProgramFilter>('all')
   const [cabinFilter, setCabinFilter] = useState<CabinFilter>('all')
@@ -100,21 +105,12 @@ export default function FlightsPage() {
       const balances: LoyaltyBalance[] = (balancesData as LoyaltyBalance[] | null) ?? []
       setHasBalances(balances.length > 0)
 
-      const balanceMap: Record<string, number> = balances.reduce(
+      const map: Record<string, number> = balances.reduce(
         (acc, b) => ({ ...acc, [b.program]: b.balance }),
         {},
       )
-
-      const rawRoutes = (routesData as AwardFlightRoute[] | null) ?? []
-      const enriched: RouteWithBalance[] = rawRoutes.map((route) => {
-        const userBalance = balanceMap[route.program] ?? 0
-        const percentage = Math.min(100, Math.round((userBalance / route.points_required) * 100))
-        const canBook = userBalance >= route.points_required
-        const almostThere = percentage >= 70 && !canBook
-        return { ...route, userBalance, percentage, canBook, almostThere }
-      })
-
-      setRoutes(enriched)
+      setBalanceMap(map)
+      setRoutes((routesData as AwardFlightRoute[] | null) ?? [])
       setLoading(false)
     }
 
@@ -122,7 +118,31 @@ export default function FlightsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const filtered = routes.filter((r) => {
+  const enrichedRoutes: RouteWithBalance[] = routes.map((route) => {
+    const rawBalance = balanceMap[route.program] ?? 0
+    const amexBalance = balanceMap['amex_mr'] ?? 0
+    const isTransferEligible = route.program === 'qff' || route.program === 'velocity'
+
+    let userBalance = rawBalance
+    let transferredPoints = 0
+    let bookableViaTransfer = false
+
+    if (includeAmexTransfers && isTransferEligible && amexBalance > 0) {
+      const result = calculateEffectiveBalance(rawBalance, amexBalance, route.program as TransferPartner)
+      const wasBookable = rawBalance >= route.points_required
+      userBalance = result.effectiveBalance
+      transferredPoints = result.transferredPoints
+      bookableViaTransfer = !wasBookable && result.effectiveBalance >= route.points_required
+    }
+
+    const percentage = Math.min(100, Math.round((userBalance / route.points_required) * 100))
+    const canBook = userBalance >= route.points_required
+    const almostThere = percentage >= 70 && !canBook
+
+    return { ...route, userBalance, percentage, canBook, almostThere, transferredPoints, bookableViaTransfer }
+  })
+
+  const filtered = enrichedRoutes.filter((r) => {
     if (programFilter !== 'all' && r.program !== programFilter) return false
     if (cabinFilter !== 'all' && r.cabin_class !== cabinFilter) return false
     if (originFilter !== 'all' && r.origin_iata !== originFilter) return false
@@ -174,8 +194,8 @@ export default function FlightsPage() {
           </Card>
         )}
 
-        {/* Filters */}
-        <div className="flex flex-wrap gap-3">
+        {/* Filters + Amex toggle */}
+        <div className="flex flex-wrap items-center gap-3">
           <Select
             value={programFilter}
             onValueChange={(v) => setProgramFilter(v as ProgramFilter)}
@@ -213,6 +233,17 @@ export default function FlightsPage() {
               <SelectItem value="BNE">Brisbane (BNE)</SelectItem>
             </SelectContent>
           </Select>
+
+          {/* Amex MR toggle */}
+          <label className="ml-auto flex cursor-pointer items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)]">
+            <input
+              type="checkbox"
+              checked={includeAmexTransfers}
+              onChange={(e) => setIncludeAmexTransfers(e.target.checked)}
+              className="h-4 w-4 accent-[var(--accent)]"
+            />
+            Include Amex MR transfers
+          </label>
         </div>
 
         {/* Can book now */}
@@ -321,11 +352,19 @@ function RouteCard({
           </span>
         </div>
 
+        {/* Amex transfer badge */}
+        {route.bookableViaTransfer && (
+          <span className="inline-block rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+            Bookable via Amex MR transfer
+          </span>
+        )}
+
         {/* Progress */}
         <RedemptionProgress
           userBalance={route.userBalance}
           pointsRequired={route.points_required}
           program={route.program}
+          transferredPoints={route.transferredPoints}
         />
 
         {/* Book button */}

--- a/app/src/components/flights/RedemptionProgress.tsx
+++ b/app/src/components/flights/RedemptionProgress.tsx
@@ -4,9 +4,15 @@ interface RedemptionProgressProps {
   userBalance: number
   pointsRequired: number
   program: 'qff' | 'velocity'
+  transferredPoints?: number
 }
 
-export function RedemptionProgress({ userBalance, pointsRequired, program }: RedemptionProgressProps) {
+export function RedemptionProgress({
+  userBalance,
+  pointsRequired,
+  program,
+  transferredPoints = 0,
+}: RedemptionProgressProps) {
   const percentage = Math.min(100, Math.round((userBalance / pointsRequired) * 100))
   const canBook = userBalance >= pointsRequired
   const pointsNeeded = Math.max(0, pointsRequired - userBalance)
@@ -21,8 +27,13 @@ export function RedemptionProgress({ userBalance, pointsRequired, program }: Red
           <div className="h-2 w-full rounded-full bg-green-500" />
         </div>
         <p className="text-xs font-medium text-green-600">Ready to book</p>
+        {transferredPoints > 0 && (
+          <p className="text-xs text-[var(--text-secondary)]">
+            Includes {transferredPoints.toLocaleString()} pts transferred from Amex MR (2:1 ratio)
+          </p>
+        )}
         <p className="text-xs text-[var(--text-secondary)]">
-          {userBalance.toLocaleString()} / {pointsRequired.toLocaleString()} pts
+          {(userBalance - transferredPoints).toLocaleString()} / {pointsRequired.toLocaleString()} pts
         </p>
       </div>
     )
@@ -44,8 +55,13 @@ export function RedemptionProgress({ userBalance, pointsRequired, program }: Red
           ? `Almost there — ${pointsNeeded.toLocaleString()} ${programLabel} pts to go`
           : `${pointsNeeded.toLocaleString()} ${programLabel} pts to go`}
       </p>
+      {transferredPoints > 0 && (
+        <p className="text-xs text-[var(--text-secondary)]">
+          Includes {transferredPoints.toLocaleString()} pts transferred from Amex MR (2:1 ratio)
+        </p>
+      )}
       <p className="text-xs text-[var(--text-secondary)]">
-        {userBalance.toLocaleString()} / {pointsRequired.toLocaleString()} pts
+        {(userBalance - transferredPoints).toLocaleString()} / {pointsRequired.toLocaleString()} pts
       </p>
     </div>
   )

--- a/app/src/lib/transferPartners.ts
+++ b/app/src/lib/transferPartners.ts
@@ -1,0 +1,40 @@
+export const AMEX_TRANSFER_PARTNERS = {
+  qff: { ratio: 2, name: 'Qantas Frequent Flyer', minTransfer: 500 },
+  velocity: { ratio: 2, name: 'Velocity Frequent Flyer', minTransfer: 500 },
+  // Future: krisflyer, cathay
+} as const
+
+export type TransferPartner = keyof typeof AMEX_TRANSFER_PARTNERS
+
+/**
+ * Convert Amex MR points to partner program points.
+ * 2 Amex MR = 1 partner point (ratio: 2).
+ */
+export function amexMrToPartnerPoints(
+  amexBalance: number,
+  partner: TransferPartner,
+): number {
+  return Math.floor(amexBalance / AMEX_TRANSFER_PARTNERS[partner].ratio)
+}
+
+/**
+ * Calculate the effective loyalty balance for a route when Amex MR transfers
+ * are included. Returns the combined balance and the number of points that
+ * would come from transferring Amex MR.
+ *
+ * Minimum transfer is 500 partner points (= 1000 Amex MR at 2:1 ratio).
+ */
+export function calculateEffectiveBalance(
+  routeBalance: number,
+  amexBalance: number,
+  program: TransferPartner,
+): { effectiveBalance: number; transferredPoints: number } {
+  const partner = AMEX_TRANSFER_PARTNERS[program]
+  const minAmexRequired = partner.minTransfer * partner.ratio
+  const transferredPoints =
+    amexBalance >= minAmexRequired ? amexMrToPartnerPoints(amexBalance, program) : 0
+  return {
+    effectiveBalance: routeBalance + transferredPoints,
+    transferredPoints,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `app/src/lib/transferPartners.ts` with `AMEX_TRANSFER_PARTNERS` config (2:1 ratio, 500pt min transfer for QFF and Velocity)
- `amexMrToPartnerPoints(amexBalance, partner)` converts Amex MR to program points
- `calculateEffectiveBalance(routeBalance, amexBalance, program)` returns effective balance + transferred points, respecting the minimum transfer threshold (1000 Amex MR = 500 program points)
- Adds `/flights` page (self-contained, includes all AF-2 + AF-3 features) with an "Include Amex MR transfers" toggle
- When toggled on: effective balances include transferred Amex MR points for QFF/Velocity routes
- Routes that become bookable **only** via transfer receive a "Bookable via Amex MR transfer" badge
- Progress bar surfaces the transfer contribution with a note: "Includes X pts transferred from Amex MR (2:1 ratio)"

## Integration note
AF-4 is self-contained. When merged after AF-2, the flights page in AF-4 should be used as it is a superset (includes Amex toggle). AF-3's `RedemptionProgress` is also included here with the `transferredPoints` prop extension.

## Test plan
- [ ] `transferPartners.ts` exports compile correctly
- [ ] `amexMrToPartnerPoints(1000, 'qff')` returns `500`
- [ ] `calculateEffectiveBalance` with amex < minTransfer returns `transferredPoints: 0`
- [ ] Toggle off: shows raw balances only
- [ ] Toggle on: routes with sufficient amex balance show increased effective balance
- [ ] Routes newly reachable via transfer show "Bookable via Amex MR transfer" badge
- [ ] Transfer note appears on progress bar when transferredPoints > 0
- [ ] Routes already bookable without transfer not affected by toggle

closes #42