### PR TITLE
[UX-1] Add onboarding progress tracking to profiles table

### DIFF
--- a/app/src/lib/onboarding.ts
+++ b/app/src/lib/onboarding.ts
@@ -1,0 +1,78 @@
+import { supabase } from "@/lib/supabase/client"
+
+export type OnboardingProgress = {
+  step: 0 | 1 | 2 | 3
+  hasAddedCard: boolean
+  hasSetSpending: boolean
+  hasViewedGap: boolean
+  onboardingCompletedAt: string | null
+  onboardingDismissedAt: string | null
+}
+
+export async function getOnboardingProgress(userId: string): Promise<OnboardingProgress> {
+  const { data, error } = await supabase
+    .from("user_profiles")
+    .select(
+      "has_added_card, has_set_spending, has_viewed_gap, onboarding_completed_at, onboarding_dismissed_at",
+    )
+    .eq("user_id", userId)
+    .single()
+
+  if (error || !data) {
+    return {
+      step: 0,
+      hasAddedCard: false,
+      hasSetSpending: false,
+      hasViewedGap: false,
+      onboardingCompletedAt: null,
+      onboardingDismissedAt: null,
+    }
+  }
+
+  const hasAddedCard = data.has_added_card ?? false
+  const hasSetSpending = data.has_set_spending ?? false
+  const hasViewedGap = data.has_viewed_gap ?? false
+
+  let step: 0 | 1 | 2 | 3 = 0
+  if (hasAddedCard) step = 1
+  if (hasAddedCard && hasSetSpending) step = 2
+  if (hasAddedCard && hasSetSpending && hasViewedGap) step = 3
+
+  return {
+    step,
+    hasAddedCard,
+    hasSetSpending,
+    hasViewedGap,
+    onboardingCompletedAt: data.onboarding_completed_at ?? null,
+    onboardingDismissedAt: data.onboarding_dismissed_at ?? null,
+  }
+}
+
+export async function markOnboardingStep(
+  userId: string,
+  field: "has_added_card" | "has_set_spending" | "has_viewed_gap",
+): Promise<void> {
+  await supabase
+    .from("user_profiles")
+    .upsert({ user_id: userId, [field]: true }, { onConflict: "user_id" })
+}
+
+export async function markOnboardingComplete(userId: string): Promise<void> {
+  await supabase.from("user_profiles").upsert(
+    {
+      user_id: userId,
+      has_added_card: true,
+      has_set_spending: true,
+      has_viewed_gap: true,
+      onboarding_completed_at: new Date().toISOString(),
+    },
+    { onConflict: "user_id" },
+  )
+}
+
+export async function dismissOnboarding(userId: string): Promise<void> {
+  await supabase.from("user_profiles").upsert(
+    { user_id: userId, onboarding_dismissed_at: new Date().toISOString() },
+    { onConflict: "user_id" },
+  )
+}

--- a/app/src/types/database.types.ts
+++ b/app/src/types/database.types.ts
@@ -719,10 +719,14 @@ export type Database = {
           created_at: string | null
           current_streak_days: number | null
           free_days_earned: number | null
+          has_added_card: boolean
+          has_set_spending: boolean
+          has_viewed_gap: boolean
           id: string
           last_active_date: string | null
           longest_streak_days: number | null
           onboarding_completed_at: string | null
+          onboarding_dismissed_at: string | null
           optimization_goal: string | null
           spending_category: string | null
           updated_at: string | null
@@ -733,10 +737,14 @@ export type Database = {
           created_at?: string | null
           current_streak_days?: number | null
           free_days_earned?: number | null
+          has_added_card?: boolean
+          has_set_spending?: boolean
+          has_viewed_gap?: boolean
           id?: string
           last_active_date?: string | null
           longest_streak_days?: number | null
           onboarding_completed_at?: string | null
+          onboarding_dismissed_at?: string | null
           optimization_goal?: string | null
           spending_category?: string | null
           updated_at?: string | null
@@ -747,10 +755,14 @@ export type Database = {
           created_at?: string | null
           current_streak_days?: number | null
           free_days_earned?: number | null
+          has_added_card?: boolean
+          has_set_spending?: boolean
+          has_viewed_gap?: boolean
           id?: string
           last_active_date?: string | null
           longest_streak_days?: number | null
           onboarding_completed_at?: string | null
+          onboarding_dismissed_at?: string | null
           optimization_goal?: string | null
           spending_category?: string | null
           updated_at?: string | null

--- a/app/supabase/migrations/20260315000000_add_onboarding_tracking.sql
+++ b/app/supabase/migrations/20260315000000_add_onboarding_tracking.sql
@@ -1,0 +1,24 @@
+-- Add onboarding progress tracking columns to user_profiles
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS has_added_card boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS has_set_spending boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS has_viewed_gap boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS onboarding_dismissed_at timestamptz;
+
+-- Backfill: users who already have cards
+UPDATE user_profiles
+SET has_added_card = true
+WHERE user_id IN (
+  SELECT DISTINCT user_id FROM user_cards
+);
+
+-- Backfill: users who already have a spending profile
+UPDATE user_profiles
+SET has_set_spending = true
+WHERE user_id IN (
+  SELECT DISTINCT user_id FROM spending_profiles
+  WHERE monthly_spend IS NOT NULL AND monthly_spend > 0
+);
+
+-- RLS policies: users can only update their own onboarding state
+-- (existing RLS on user_profiles covers read/write by user_id)


### PR DESCRIPTION
## Summary
- Adds `has_added_card`, `has_set_spending`, `has_viewed_gap` boolean columns to `user_profiles`
- Adds `onboarding_dismissed_at` timestamptz column
- SQL migration with backfill for existing users who already have cards/spending data
- TypeScript types updated in `database.types.ts`
- New `src/lib/onboarding.ts` with `getOnboardingProgress()`, `markOnboardingStep()`, `markOnboardingComplete()`, and `dismissOnboarding()` helpers

## Test plan
- [ ] Run migration against staging Supabase — verify columns created with correct defaults
- [ ] Verify backfill: existing users with `user_cards` rows have `has_added_card = true`
- [ ] Verify backfill: existing users with `spending_profiles` have `has_set_spending = true`
- [ ] `getOnboardingProgress(userId)` returns correct `step` (0–3) for users at each stage
- [ ] New users default to `step: 0`, all flags `false`

Closes #105