### PR TITLE
[BD-1] Create bank_exclusion_periods table and seed 10 AU banks

### DIFF
--- a/app/src/types/database.types.ts
+++ b/app/src/types/database.types.ts
@@ -66,6 +66,48 @@ export type Database = {
         }
         Relationships: []
       }
+      bank_exclusion_periods: {
+        Row: {
+          id: string
+          bank_name: string
+          bank_slug: string
+          exclusion_months: number | null
+          exclusion_note: string | null
+          tc_exact_quote: string | null
+          applies_to: string | null
+          confidence_pct: number | null
+          source_url: string | null
+          data_last_updated: string
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          bank_name: string
+          bank_slug: string
+          exclusion_months?: number | null
+          exclusion_note?: string | null
+          tc_exact_quote?: string | null
+          applies_to?: string | null
+          confidence_pct?: number | null
+          source_url?: string | null
+          data_last_updated?: string
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          bank_name?: string
+          bank_slug?: string
+          exclusion_months?: number | null
+          exclusion_note?: string | null
+          tc_exact_quote?: string | null
+          applies_to?: string | null
+          confidence_pct?: number | null
+          source_url?: string | null
+          data_last_updated?: string
+          created_at?: string | null
+        }
+        Relationships: []
+      }
       award_flight_routes: {
         Row: {
           id: string

--- a/app/supabase/migrations/20260315100000_create_bank_exclusion_periods.sql
+++ b/app/supabase/migrations/20260315100000_create_bank_exclusion_periods.sql
@@ -1,0 +1,129 @@
+CREATE TABLE IF NOT EXISTS public.bank_exclusion_periods (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  bank_name text NOT NULL,
+  bank_slug text UNIQUE NOT NULL,
+  exclusion_months int,
+  exclusion_note text,
+  tc_exact_quote text,
+  applies_to text,
+  confidence_pct int,
+  source_url text,
+  data_last_updated date NOT NULL DEFAULT CURRENT_DATE,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.bank_exclusion_periods ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Read-only for authenticated users" ON public.bank_exclusion_periods
+  FOR SELECT TO authenticated USING (true);
+
+-- Seed data (idempotent via upsert on bank_slug)
+INSERT INTO public.bank_exclusion_periods
+  (bank_name, bank_slug, exclusion_months, exclusion_note, applies_to, confidence_pct, data_last_updated)
+VALUES
+  (
+    'ANZ',
+    'anz',
+    24,
+    'Must not have received a welcome bonus on any ANZ rewards credit card in the preceding 24 months.',
+    'per_card_product',
+    95,
+    '2025-01-01'
+  ),
+  (
+    'Westpac',
+    'westpac',
+    24,
+    'Must not have held a Westpac rewards card or received a bonus in the previous 24 months.',
+    'per_card_product',
+    95,
+    '2025-01-01'
+  ),
+  (
+    'St.George / Bank of Melbourne / BankSA',
+    'stgeorge-bom-banksa',
+    24,
+    'All three brands share the same T&C exclusion period — 24 months across the family.',
+    'brand_family',
+    90,
+    '2025-01-01'
+  ),
+  (
+    'Bankwest',
+    'bankwest',
+    24,
+    'Must not have held a Bankwest credit card that earned points in the last 24 months.',
+    'per_card_product',
+    95,
+    '2025-01-01'
+  ),
+  (
+    'CommBank',
+    'commbank',
+    24,
+    'Must not have received a bonus on a CommBank awards card in the previous 24 months.',
+    'per_card_product',
+    95,
+    '2025-01-01'
+  ),
+  (
+    'NAB',
+    'nab',
+    24,
+    'Changed from 18 months to 24 months in Sep 2025. Qantas Rewards family and NAB Rewards family are tracked independently — holding one does not affect eligibility for the other.',
+    'per_rewards_family',
+    90,
+    '2025-09-01'
+  ),
+  (
+    'Amex AU',
+    'amex-au',
+    18,
+    'Applies across ALL personal Amex products — receiving a welcome bonus on any personal Amex card starts the 18-month exclusion window for all other personal Amex cards.',
+    'all_personal_amex',
+    95,
+    '2025-01-01'
+  ),
+  (
+    'HSBC AU (Qantas)',
+    'hsbc-au-qantas',
+    12,
+    'HSBC Qantas card — 12-month exclusion period from last bonus on HSBC Qantas product.',
+    'qantas_card_only',
+    80,
+    '2025-01-01'
+  ),
+  (
+    'HSBC AU (Star Alliance)',
+    'hsbc-au-star-alliance',
+    18,
+    'HSBC Star Alliance card — 18-month exclusion period from last bonus on HSBC Star Alliance product.',
+    'star_alliance_card_only',
+    80,
+    '2025-01-01'
+  ),
+  (
+    'Virgin Money AU',
+    'virgin-money-au',
+    NULL,
+    'No confirmed month-based exclusion window found. T&C language references "new applicants" but does not specify a time period. Verify on Virgin Money website before applying.',
+    'unknown',
+    40,
+    '2025-01-01'
+  ),
+  (
+    'Macquarie',
+    'macquarie',
+    NULL,
+    'Only "new applicants" language found in T&C — no confirmed exclusion period. Verify on Macquarie website before applying.',
+    'unknown',
+    40,
+    '2025-01-01'
+  )
+ON CONFLICT (bank_slug) DO UPDATE SET
+  bank_name = EXCLUDED.bank_name,
+  exclusion_months = EXCLUDED.exclusion_months,
+  exclusion_note = EXCLUDED.exclusion_note,
+  applies_to = EXCLUDED.applies_to,
+  confidence_pct = EXCLUDED.confidence_pct,
+  data_last_updated = EXCLUDED.data_last_updated;


### PR DESCRIPTION
## Summary
- Creates `bank_exclusion_periods` table with full schema (bank_slug unique key, exclusion_months nullable, applies_to, confidence_pct, data_last_updated)
- Seeds 11 rows covering all 10 AU banks specified: ANZ, Westpac, St.George/BOM/BankSA, Bankwest, CommBank, NAB (24mo updated Sep 2025), Amex AU (18mo cross-product), HSBC AU Qantas (12mo), HSBC AU Star Alliance (18mo), Virgin Money AU (NULL), Macquarie (NULL)
- RLS enabled: read-only for authenticated users
- Seed is idempotent via upsert on `bank_slug`
- TypeScript types added to `database.types.ts`

## Test plan
- [ ] Migration applies cleanly without errors
- [ ] 11 rows present in `bank_exclusion_periods` table
- [ ] Amex row has `applies_to = 'all_personal_amex'`
- [ ] NAB row has 24mo with note about Qantas/NAB Rewards family separation
- [ ] HSBC has two rows (12mo Qantas, 18mo Star Alliance)
- [ ] Virgin Money and Macquarie have `exclusion_months = NULL`
- [ ] Upsert re-run produces same 11 rows (idempotent)

Closes #107