### PR TITLE
[UX-4] Empty state redesign — /cards and /spending pages

### DIFF
--- a/app/src/app/cards/page.tsx
+++ b/app/src/app/cards/page.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 import { AddCardForm } from "@/components/cards/AddCardForm"
 import { CardFilters } from "@/components/cards/CardFilters"
 import { CardGrid, type CardRecord } from "@/components/cards/CardGrid"
+import { CardsEmptyState } from "@/components/cards/CardsEmptyState"
 import { AppShell } from "@/components/layout/AppShell"
 import { useCatalog } from "@/contexts/CatalogContext"
 import { supabase } from "@/lib/supabase/client"
@@ -16,6 +17,7 @@ export default function CardsPage() {
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState("")
   const [bank, setBank] = useState<string | null>(null)
+  const [userCardCount, setUserCardCount] = useState<number | null>(null)
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -26,6 +28,13 @@ export default function CardsPage() {
         window.location.href = `/login?redirect=${encodeURIComponent("/cards")}`
         return
       }
+
+      // Check if user has any tracked cards for empty state
+      const { count } = await supabase
+        .from("user_cards")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", session.user.id)
+      setUserCardCount(count ?? 0)
       setLoading(false)
     }
     checkAuth()
@@ -74,8 +83,11 @@ export default function CardsPage() {
           </p>
         </div>
 
+        {/* Value-driven empty state when no cards tracked yet */}
+        {userCardCount === 0 && <CardsEmptyState />}
+
         <AddCardForm cards={cards} onCreated={() => {
-          // Redirect to dashboard to see the newly added card
+          setUserCardCount((c) => (c ?? 0) + 1)
           window.location.href = '/dashboard';
         }} />
 

--- a/app/src/app/spending/page.tsx
+++ b/app/src/app/spending/page.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import { SpendingEmptyState } from "@/components/forms/SpendingEmptyState"
 
 interface UserCard {
   id: string
@@ -249,22 +250,7 @@ export default function SpendingTrackerPage() {
 
         {/* Card spending progress */}
         {userCards.length === 0 ? (
-          <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-            <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
-              <p className="font-medium text-[var(--text-primary)]">No active cards</p>
-              <p className="text-sm text-[var(--text-secondary)]">
-                Add cards with spending requirements to track your progress.
-              </p>
-              <Button
-                size="sm"
-                className="rounded-full"
-                style={{ background: "var(--gradient-cta)" }}
-                onClick={() => (window.location.href = "/cards")}
-              >
-                Add cards
-              </Button>
-            </CardContent>
-          </Card>
+          <SpendingEmptyState />
         ) : (
           <div className="space-y-4">
             {userCards.map((card) => {

--- a/app/src/components/cards/CardsEmptyState.tsx
+++ b/app/src/components/cards/CardsEmptyState.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { CreditCard } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { EmptyState } from "@/components/ui/EmptyState"
+
+export function CardsEmptyState() {
+  const router = useRouter()
+
+  const ghostPreview = (
+    <div className="rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4 text-left">
+      <p className="text-xs font-medium text-[var(--text-secondary)]">ANZ Rewards Visa</p>
+      <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">1.0 pt per $1</p>
+      <div className="mt-2 h-2 rounded-full bg-[var(--surface-strong)]" />
+      <div className="mt-1.5 h-2 w-2/3 rounded-full bg-[var(--surface-strong)]" />
+    </div>
+  )
+
+  return (
+    <EmptyState
+      icon={<CreditCard className="h-8 w-8" />}
+      heading="Your reward engine starts here."
+      body="See exactly how much you're earning — and where you're missing out. Add your current cards to get started."
+      ghost={ghostPreview}
+      cta={
+        <Button
+          className="rounded-full text-white shadow-sm"
+          style={{ background: "var(--gradient-cta)" }}
+          onClick={() => router.push("/cards")}
+        >
+          <CreditCard className="mr-1.5 h-3.5 w-3.5" />
+          Add your first card
+        </Button>
+      }
+      socialProof="The average Australian holds 2 rewards cards — most don't know their earn rates by category."
+    />
+  )
+}

--- a/app/src/components/forms/SpendingEmptyState.tsx
+++ b/app/src/components/forms/SpendingEmptyState.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { Wallet, Upload } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { EmptyState } from "@/components/ui/EmptyState"
+
+export function SpendingEmptyState() {
+  const router = useRouter()
+
+  const ghostPreview = (
+    <div className="rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4 text-left space-y-2">
+      {["Groceries", "Dining", "Travel"].map((cat) => (
+        <div key={cat} className="flex items-center gap-2">
+          <span className="w-16 text-xs text-[var(--text-secondary)]">{cat}</span>
+          <div className="flex-1 h-2 rounded-full bg-[var(--surface-strong)]" />
+          <span className="text-xs text-[var(--text-secondary)]">$—</span>
+        </div>
+      ))}
+    </div>
+  )
+
+  return (
+    <EmptyState
+      icon={<Wallet className="h-8 w-8" />}
+      heading="Your recommendations are only as good as your spending data."
+      body="Takes 2 minutes — use estimates, update anytime. We'll personalise your reward gap based on your actual spending mix."
+      ghost={ghostPreview}
+      cta={
+        <>
+          <Button
+            className="rounded-full text-white shadow-sm"
+            style={{ background: "var(--gradient-cta)" }}
+            onClick={() => router.push("/spending")}
+          >
+            Set up my spending profile
+          </Button>
+          <Button
+            variant="outline"
+            className="rounded-full"
+            onClick={() => router.push("/statements")}
+          >
+            <Upload className="mr-1.5 h-3.5 w-3.5" />
+            Import bank statement
+          </Button>
+        </>
+      }
+      socialProof="Tip: Import your bank statement to auto-populate your spending categories."
+    />
+  )
+}

--- a/app/src/components/ui/EmptyState.tsx
+++ b/app/src/components/ui/EmptyState.tsx
@@ -1,0 +1,48 @@
+import { type ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  icon?: ReactNode
+  heading: string
+  body: string
+  ghost?: ReactNode
+  cta: ReactNode
+  socialProof?: string
+  className?: string
+}
+
+export function EmptyState({ icon, heading, body, ghost, cta, socialProof, className }: Props) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center gap-5 rounded-2xl border border-dashed border-[var(--border-default)] bg-[var(--surface-muted)] px-6 py-10 text-center",
+        className,
+      )}
+    >
+      {icon && <div className="text-[var(--accent)]">{icon}</div>}
+
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold text-[var(--text-primary)]">{heading}</h2>
+        <p className="mx-auto max-w-sm text-sm text-[var(--text-secondary)]">{body}</p>
+      </div>
+
+      {/* Ghost preview */}
+      {ghost && (
+        <div className="relative w-full max-w-xs overflow-hidden rounded-xl">
+          <div className="pointer-events-none select-none blur-[2px] opacity-40">{ghost}</div>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="rounded-full bg-[var(--surface)]/80 px-3 py-1 text-xs font-medium text-[var(--text-secondary)] backdrop-blur-sm ring-1 ring-[var(--border-default)]">
+              🔒 Set up to unlock
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col items-center gap-2 sm:flex-row">{cta}</div>
+
+      {socialProof && (
+        <p className="text-xs italic text-[var(--text-secondary)]">{socialProof}</p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New reusable `EmptyState` component with icon, ghost preview, CTA, and social proof slots
- `/cards` page: fetches user's tracked card count; shows `CardsEmptyState` when count = 0 with ghost card preview and "Add your first card" CTA
- `/spending` page: shows `SpendingEmptyState` with ghost category breakdown and dual CTA (manual + import statement) when no active cards exist
- Copy follows "Let's set this up" tone replacing "No data yet"

## Test plan
- [ ] New user (0 tracked cards): `/cards` shows value-driven empty state with ghost preview above catalog
- [ ] After adding first card: empty state disappears on next visit
- [ ] New user (0 active cards): `/spending` shows redesigned empty state
- [ ] "Set up my spending profile" routes to `/spending`
- [ ] "Import bank statement" routes to `/statements`
- [ ] Ghost previews render as blurred/semi-transparent with lock indicator
- [ ] Mobile: both pages responsive

Closes #110