### PR TITLE
[BD-5] Add data_last_updated metadata to all award data tables

### DIFF
--- a/app/src/lib/award-data.ts
+++ b/app/src/lib/award-data.ts
@@ -1,0 +1,39 @@
+import { supabase } from '@/lib/supabase/client'
+
+export interface DataFreshness {
+  tableName: string
+  lastUpdated: string | null
+  daysSinceUpdate: number | null
+  status: 'fresh' | 'stale' | 'outdated' | 'unknown'
+}
+
+interface DataFreshnessRow {
+  table_name: string | null
+  last_updated: string | null
+  days_since_update: number | null
+}
+
+const STALE_THRESHOLD_DAYS = 180
+const OUTDATED_THRESHOLD_DAYS = 365
+
+function classifyFreshness(daysSinceUpdate: number | null): DataFreshness['status'] {
+  if (daysSinceUpdate === null) return 'unknown'
+  if (daysSinceUpdate > OUTDATED_THRESHOLD_DAYS) return 'outdated'
+  if (daysSinceUpdate > STALE_THRESHOLD_DAYS) return 'stale'
+  return 'fresh'
+}
+
+export async function getAwardDataFreshness(): Promise<DataFreshness[]> {
+  const { data, error } = await supabase
+    .from('award_data_freshness' as never)
+    .select('table_name, last_updated, days_since_update')
+
+  if (error || !data) return []
+
+  return (data as DataFreshnessRow[]).map((row) => ({
+    tableName: row.table_name ?? '',
+    lastUpdated: row.last_updated,
+    daysSinceUpdate: row.days_since_update,
+    status: classifyFreshness(row.days_since_update),
+  }))
+}

--- a/app/supabase/migrations/20260315100400_add_data_freshness_view.sql
+++ b/app/supabase/migrations/20260315100400_add_data_freshness_view.sql
@@ -1,0 +1,26 @@
+-- award_data_freshness view — aggregates data_last_updated per award table
+-- Staleness thresholds: >180 days = stale (warn), >365 days = outdated (alert)
+CREATE OR REPLACE VIEW public.award_data_freshness AS
+SELECT
+  'bank_exclusion_periods'::text AS table_name,
+  MAX(data_last_updated) AS last_updated,
+  (CURRENT_DATE - MAX(data_last_updated)) AS days_since_update
+FROM public.bank_exclusion_periods
+UNION ALL
+SELECT
+  'qantas_award_zones'::text,
+  MAX(data_last_updated),
+  (CURRENT_DATE - MAX(data_last_updated))
+FROM public.qantas_award_zones
+UNION ALL
+SELECT
+  'award_routes'::text,
+  MAX(data_last_updated),
+  (CURRENT_DATE - MAX(data_last_updated))
+FROM public.award_routes
+UNION ALL
+SELECT
+  'velocity_award_pricing'::text,
+  MAX(data_last_updated),
+  (CURRENT_DATE - MAX(data_last_updated))
+FROM public.velocity_award_pricing;


### PR DESCRIPTION
## Summary
- All four award tables (bank_exclusion_periods, qantas_award_zones, award_routes, velocity_award_pricing) already include `data_last_updated date NOT NULL DEFAULT CURRENT_DATE` columns from their respective BD-1 through BD-4 migrations
- Creates `award_data_freshness` SQL view that aggregates `MAX(data_last_updated)` and `days_since_update` per table
- Adds `getAwardDataFreshness()` TypeScript helper in `src/lib/award-data.ts` that fetches the view and classifies data as fresh / stale (>180 days) / outdated (>365 days)
- Exports `DataFreshness` interface for use in UI components

## Test plan
- [ ] Migration applies cleanly
- [ ] `SELECT * FROM award_data_freshness` returns 4 rows (one per table)
- [ ] `getAwardDataFreshness()` returns 4 entries with correct `status` classification
- [ ] A table with `data_last_updated` = 200 days ago classifies as `stale`
- [ ] A table with `data_last_updated` = 400 days ago classifies as `outdated`
- [ ] A table with `data_last_updated` = today classifies as `fresh`

Closes #115