### PR TITLE
[UX-8] Dollar-value framing — convert points to $ throughout app

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -17,6 +17,7 @@ import { BonusConfirmationBanner } from "@/components/dashboard/BonusConfirmatio
 import { supabase } from "@/lib/supabase/client"
 import { getRecommendations } from "@/lib/recommendations"
 import { GOALS, calculateMultiCardPaths } from "@/lib/projections"
+import { formatPointsWithValue } from "@/lib/points"
 import { useCatalog } from "@/contexts/CatalogContext"
 import { useAnalytics } from "@/contexts/AnalyticsContext"
 import type { Database } from "@/types/database.types"
@@ -335,7 +336,7 @@ export default function DashboardPage() {
                     </span>
                   </p>
                   <div className="flex items-center gap-3 text-xs text-[var(--text-secondary)]">
-                    <span>{projection.path.totalPoints.toLocaleString()} pts</span>
+                    <span>{formatPointsWithValue(projection.path.totalPoints, "qantas", "flights_business")}</span>
                     <span>·</span>
                     <span>${projection.path.totalCost} fees</span>
                     <span>·</span>

--- a/app/src/app/projections/page.tsx
+++ b/app/src/app/projections/page.tsx
@@ -15,6 +15,7 @@ import { PointsBalanceWidget } from "@/components/profile/PointsBalanceWidget"
 import { UnavailableCardAlert } from "@/components/projections/UnavailableCardAlert"
 import { supabase } from "@/lib/supabase/client"
 import { GOALS, calculateMultiCardPaths, type RedemptionGoal } from "@/lib/projections"
+import { formatPointsWithValue } from "@/lib/points"
 import { checkForUnavailableCards } from "@/lib/unavailable-cards"
 import { useCatalog } from "@/contexts/CatalogContext"
 import type { Database } from "@/types/database.types"
@@ -217,12 +218,12 @@ export default function ProjectionsPage() {
                   <p className="text-sm text-[var(--text-secondary)]">{selectedGoal.description}</p>
                 </div>
                 <div className="text-right">
-                  <p className="text-sm text-[var(--text-secondary)]">Points Needed</p>
+                  <p className="text-sm text-[var(--text-secondary)]">Goal value</p>
                   <p className="text-2xl font-bold text-[var(--accent)]">
-                    {Math.max(0, selectedGoal.pointsRequired - currentPoints).toLocaleString()}
+                    {Math.max(0, selectedGoal.pointsRequired - currentPoints).toLocaleString()} pts
                   </p>
                   <p className="text-xs text-[var(--text-secondary)]">
-                    of {selectedGoal.pointsRequired.toLocaleString()} required
+                    {formatPointsWithValue(selectedGoal.pointsRequired, "qantas", "flights_business")}
                   </p>
                 </div>
               </div>

--- a/app/src/components/dashboard/RecommendationCard.tsx
+++ b/app/src/components/dashboard/RecommendationCard.tsx
@@ -5,6 +5,7 @@ import { ExternalLink, TrendingUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import type { Recommendation } from "@/lib/recommendations"
+import { formatPointsAsDollars, formatPointsWithValue } from "@/lib/points"
 
 interface RecommendationCardProps {
   recommendation: Recommendation
@@ -42,10 +43,12 @@ export function RecommendationCard({
         <div className="flex items-baseline gap-4 text-sm">
           {card.welcome_bonus_points && (
             <div>
-              <span className="text-xl font-bold text-[var(--text-primary)]">
-                {card.welcome_bonus_points.toLocaleString()}
+              <span className="text-xl font-bold text-[var(--accent)]">
+                {formatPointsAsDollars(card.welcome_bonus_points, card.points_currency ?? "default")}
               </span>
-              <span className="ml-1 text-[var(--text-secondary)]">pts</span>
+              <span className="ml-1 text-xs text-[var(--text-secondary)]">
+                ({card.welcome_bonus_points.toLocaleString()} pts)
+              </span>
             </div>
           )}
           {card.annual_fee !== null && (
@@ -97,12 +100,15 @@ export function RecommendationCard({
           <div className="flex flex-wrap items-baseline gap-6">
             {card.welcome_bonus_points && (
               <div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-4xl font-bold text-[var(--text-primary)]">
-                    {card.welcome_bonus_points.toLocaleString()}
+                <div className="flex items-baseline gap-1.5">
+                  <span className="text-4xl font-bold text-[var(--accent)]">
+                    {formatPointsAsDollars(card.welcome_bonus_points, card.points_currency ?? "default")}
                   </span>
-                  <span className="text-base text-[var(--text-secondary)]">bonus points</span>
+                  <span className="text-sm text-[var(--text-secondary)]">bonus value</span>
                 </div>
+                <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
+                  {formatPointsWithValue(card.welcome_bonus_points, card.points_currency ?? "default")}
+                </p>
                 {card.bonus_spend_requirement && (
                   <p className="mt-1 text-sm text-[var(--text-secondary)]">
                     Spend ${card.bonus_spend_requirement.toLocaleString()} in{" "}

--- a/app/src/lib/points.ts
+++ b/app/src/lib/points.ts
@@ -1,0 +1,99 @@
+/**
+ * Points-to-dollar conversion utility.
+ *
+ * Conversion rates (AUD per point) are based on Australian Frequent Flyer
+ * community benchmarks and AFF valuations.
+ */
+
+export type PointsProgram = string
+
+export type RedemptionType = "flights_business" | "flights_economy" | "cashback" | "gift_cards" | "default"
+
+const BASE_RATES: Record<string, number> = {
+  qantas: 0.02,         // QFF — business class benchmark
+  "qantas frequent flyer": 0.02,
+  velocity: 0.017,      // Velocity — business class benchmark
+  "velocity frequent flyer": 0.017,
+  "amex membership rewards": 0.01,
+  mr: 0.01,
+  "mr gateway": 0.01,
+  "anz rewards": 0.006,
+  "nab rewards": 0.006,
+  "cba awards": 0.006,
+  altitude: 0.006,
+  amplify: 0.006,
+  "bankwest more": 0.006,
+}
+
+const REDEMPTION_MULTIPLIERS: Record<RedemptionType, number> = {
+  flights_business: 1.0,    // Full rate — aspirational benchmark
+  flights_economy: 0.6,
+  cashback: 0.4,
+  gift_cards: 0.5,
+  default: 1.0,
+}
+
+/**
+ * Convert points to an AUD dollar value.
+ * @param pts Number of points
+ * @param program Points program name (case-insensitive)
+ * @param redemptionType Redemption context (defaults to flights_business)
+ */
+export function pointsToDollars(
+  pts: number,
+  program: PointsProgram = "default",
+  redemptionType: RedemptionType = "default",
+): number {
+  const key = program.toLowerCase().trim()
+  const rate = BASE_RATES[key] ?? 0.006  // conservative fallback
+  const multiplier = REDEMPTION_MULTIPLIERS[redemptionType] ?? 1.0
+  return Math.round(pts * rate * multiplier * 100) / 100
+}
+
+/**
+ * Format a points count with its dollar equivalent.
+ * e.g. "45,000 pts ($900 value)"
+ */
+export function formatPointsWithValue(
+  pts: number,
+  program: PointsProgram = "default",
+  redemptionType: RedemptionType = "default",
+): string {
+  const dollars = pointsToDollars(pts, program, redemptionType)
+  const dollarsFormatted = new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(dollars)
+
+  return `${pts.toLocaleString("en-AU")} pts (${dollarsFormatted} value)`
+}
+
+/**
+ * Format just the dollar value for primary display contexts.
+ */
+export function formatPointsAsDollars(
+  pts: number,
+  program: PointsProgram = "default",
+  redemptionType: RedemptionType = "default",
+): string {
+  const dollars = pointsToDollars(pts, program, redemptionType)
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(dollars)
+}
+
+/**
+ * Calculate annual earn in dollars from earn rate + monthly spend.
+ */
+export function annualEarnDollars(
+  earnRatePerDollar: number,
+  monthlySpend: number,
+  program: PointsProgram = "default",
+  redemptionType: RedemptionType = "default",
+): number {
+  const annualPoints = earnRatePerDollar * monthlySpend * 12
+  return pointsToDollars(annualPoints, program, redemptionType)
+}


### PR DESCRIPTION
## Summary
- New `src/lib/points.ts` utility: `pointsToDollars()`, `formatPointsWithValue()`, `formatPointsAsDollars()`, `annualEarnDollars()`
- Conversion rates by program (Qantas 2¢, Velocity 1.7¢, Amex MR 1¢, bank programs 0.6¢) with redemption type multipliers
- Configurable via `PointsProgram` + `RedemptionType` parameters; fallback to conservative 0.6¢ if unknown
- `RecommendationCard`: primary display is now dollar value ("$900 value"), pts shown as secondary
- Dashboard projection section: shows `formatPointsWithValue()` e.g. "45,000 pts ($900 value)"
- Projections page: goal badge shows dollar equivalent of redemption value

## Test plan
- [ ] `pointsToDollars(45000, "qantas")` returns `900`
- [ ] `pointsToDollars(45000, "unknown_program")` falls back to 0.6¢ baseline
- [ ] `formatPointsWithValue(45000, "qantas")` returns `"45,000 pts ($900 value)"`
- [ ] Recommendation hero card shows dollar value prominently
- [ ] Recommendation compact card shows dollar value
- [ ] Dashboard projection shows pts + dollar equivalent
- [ ] Projections page goal value shows dollar equivalent

Closes #118