### PR TITLE
CA-1: Create cdr_products table and CDR Register client

### DIFF
--- a/app/src/lib/cdr/register.ts
+++ b/app/src/lib/cdr/register.ts
@@ -1,0 +1,74 @@
+// CDR Register client — discovers CDR data holder base URLs
+const CDR_REGISTER_URL = 'https://api.cdr.gov.au/cdr-register/v1/banking/data-holders/brands/summary'
+
+export interface CDRDataHolder {
+  bankName: string
+  bankSlug: string
+  publicBaseUri: string
+}
+
+// Fallback URLs in case CDR Register is unavailable
+const CDR_FALLBACKS: CDRDataHolder[] = [
+  { bankName: 'ANZ', bankSlug: 'anz', publicBaseUri: 'https://api.anz/cds-au/v1/banking' },
+  { bankName: 'Commonwealth Bank', bankSlug: 'cba', publicBaseUri: 'https://api.commbank.com.au/public/cds-au/v1/banking' },
+  { bankName: 'NAB', bankSlug: 'nab', publicBaseUri: 'https://api.nab.com.au/cds-au/v1/banking' },
+  { bankName: 'Westpac', bankSlug: 'westpac', publicBaseUri: 'https://openbank.api.westpac.com.au/cds-au/v1/banking' },
+]
+
+function toBankSlug(legalEntityName: string): string {
+  const name = legalEntityName.toLowerCase()
+  if (name.includes('anz') || name.includes('australia and new zealand')) return 'anz'
+  if (name.includes('commonwealth') || name.includes('commbank') || name.includes('cba')) return 'cba'
+  if (name.includes('nab') || name.includes('national australia')) return 'nab'
+  if (name.includes('westpac')) return 'westpac'
+  if (name.includes('st.george') || name.includes('st george')) return 'stgeorge'
+  if (name.includes('bankwest')) return 'bankwest'
+  if (name.includes('hsbc')) return 'hsbc'
+  if (name.includes('macquarie')) return 'macquarie'
+  // Generate slug from name
+  return legalEntityName.toLowerCase().replace(/[^a-z0-9]/g, '-').replace(/-+/g, '-').slice(0, 20)
+}
+
+export async function getCDRDataHolders(): Promise<CDRDataHolder[]> {
+  try {
+    const response = await fetch(CDR_REGISTER_URL, {
+      headers: { 'x-v': '1' },
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      console.warn(`CDR Register returned ${response.status}, using fallbacks`)
+      return CDR_FALLBACKS
+    }
+
+    const data = await response.json() as {
+      data: Array<{
+        legalEntityName?: string
+        brandName?: string
+        endpointDetail?: { publicBaseUri?: string }
+      }>
+    }
+
+    const holders: CDRDataHolder[] = []
+
+    for (const holder of data.data ?? []) {
+      const publicBaseUri = holder.endpointDetail?.publicBaseUri
+      if (!publicBaseUri) continue
+
+      const bankName = holder.brandName ?? holder.legalEntityName ?? 'Unknown'
+      const bankSlug = toBankSlug(holder.legalEntityName ?? bankName)
+
+      holders.push({ bankName, bankSlug, publicBaseUri })
+    }
+
+    if (holders.length === 0) {
+      console.warn('CDR Register returned no holders, using fallbacks')
+      return CDR_FALLBACKS
+    }
+
+    return holders
+  } catch (error) {
+    console.warn('CDR Register fetch failed, using fallbacks:', error)
+    return CDR_FALLBACKS
+  }
+}

--- a/app/src/types/database.types.ts
+++ b/app/src/types/database.types.ts
@@ -514,6 +514,7 @@ export type Database = {
           bonus_spend_requirement: number | null
           bonus_spend_window_months: number | null
           bonus_structure: Json | null
+          change_detected_at: string | null
           created_at: string | null
           earn_rate_primary: number | null
           earn_rate_secondary: number | null
@@ -525,6 +526,7 @@ export type Database = {
           last_verified_at: string | null
           min_income: number | null
           name: string
+          needs_verification: boolean | null
           network: string | null
           notes: string | null
           offer_expiry_date: string | null
@@ -533,6 +535,7 @@ export type Database = {
           scrape_source: string | null
           scrape_url: string | null
           total_annual_fee: number | null
+          verification_priority: string | null
           welcome_bonus_points: number | null
         }
         Insert: {
@@ -543,6 +546,7 @@ export type Database = {
           bonus_spend_requirement?: number | null
           bonus_spend_window_months?: number | null
           bonus_structure?: Json | null
+          change_detected_at?: string | null
           created_at?: string | null
           earn_rate_primary?: number | null
           earn_rate_secondary?: number | null
@@ -554,6 +558,7 @@ export type Database = {
           last_verified_at?: string | null
           min_income?: number | null
           name: string
+          needs_verification?: boolean | null
           network?: string | null
           notes?: string | null
           offer_expiry_date?: string | null
@@ -562,6 +567,7 @@ export type Database = {
           scrape_source?: string | null
           scrape_url?: string | null
           total_annual_fee?: number | null
+          verification_priority?: string | null
           welcome_bonus_points?: number | null
         }
         Update: {
@@ -572,6 +578,7 @@ export type Database = {
           bonus_spend_requirement?: number | null
           bonus_spend_window_months?: number | null
           bonus_structure?: Json | null
+          change_detected_at?: string | null
           created_at?: string | null
           earn_rate_primary?: number | null
           earn_rate_secondary?: number | null
@@ -583,6 +590,7 @@ export type Database = {
           last_verified_at?: string | null
           min_income?: number | null
           name?: string
+          needs_verification?: boolean | null
           network?: string | null
           notes?: string | null
           offer_expiry_date?: string | null
@@ -591,6 +599,7 @@ export type Database = {
           scrape_source?: string | null
           scrape_url?: string | null
           total_annual_fee?: number | null
+          verification_priority?: string | null
           welcome_bonus_points?: number | null
         }
         Relationships: []
@@ -1054,6 +1063,66 @@ export type Database = {
         }
         Relationships: []
       }
+      cdr_products: {
+        Row: {
+          id: string
+          product_id: string
+          bank_slug: string
+          bank_name: string
+          product_name: string
+          product_category: string | null
+          annual_fee_amount: number | null
+          annual_fee_waiver_condition: string | null
+          loyalty_program_name: string | null
+          purchase_rate: number | null
+          min_credit_limit: number | null
+          raw_json: Json
+          cdr_effective_from: string | null
+          last_fetched_at: string | null
+          is_active: boolean | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          product_id: string
+          bank_slug: string
+          bank_name: string
+          product_name: string
+          product_category?: string | null
+          annual_fee_amount?: number | null
+          annual_fee_waiver_condition?: string | null
+          loyalty_program_name?: string | null
+          purchase_rate?: number | null
+          min_credit_limit?: number | null
+          raw_json: Json
+          cdr_effective_from?: string | null
+          last_fetched_at?: string | null
+          is_active?: boolean | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          product_id?: string
+          bank_slug?: string
+          bank_name?: string
+          product_name?: string
+          product_category?: string | null
+          annual_fee_amount?: number | null
+          annual_fee_waiver_condition?: string | null
+          loyalty_program_name?: string | null
+          purchase_rate?: number | null
+          min_credit_limit?: number | null
+          raw_json?: Json
+          cdr_effective_from?: string | null
+          last_fetched_at?: string | null
+          is_active?: boolean | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never
@@ -1197,3 +1266,5 @@ export const Constants = {
     Enums: {},
   },
 } as const
+
+export type CdrProduct = Tables<'cdr_products'>

--- a/app/supabase/migrations/20260317120734_create_cdr_products.sql
+++ b/app/supabase/migrations/20260317120734_create_cdr_products.sql
@@ -1,0 +1,33 @@
+-- Create cdr_products table for CDR Open Banking data
+CREATE TABLE IF NOT EXISTS cdr_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id text NOT NULL,
+  bank_slug text NOT NULL,
+  bank_name text NOT NULL,
+  product_name text NOT NULL,
+  product_category text,
+  annual_fee_amount numeric,
+  annual_fee_waiver_condition text,
+  loyalty_program_name text,
+  purchase_rate numeric,
+  min_credit_limit numeric,
+  raw_json jsonb NOT NULL,
+  cdr_effective_from timestamptz,
+  last_fetched_at timestamptz DEFAULT now(),
+  is_active boolean DEFAULT true,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE(bank_slug, product_id)
+);
+
+-- RLS policies
+ALTER TABLE cdr_products ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can read
+CREATE POLICY "authenticated_select_cdr_products" ON cdr_products
+  FOR SELECT TO authenticated USING (true);
+
+-- Service role can do everything (bypasses RLS by default)
+-- Ensure service role has full access
+GRANT ALL ON cdr_products TO service_role;
+GRANT SELECT ON cdr_products TO authenticated;


### PR DESCRIPTION
## Summary
- Adds `cdr_products` table with RLS policies for CDR Open Banking data
- Implements `getCDRDataHolders()` client that discovers bank CDR endpoints from the CDR Register
- Includes hard-coded fallbacks for ANZ, CBA, NAB, Westpac
- Adds `CdrProduct` TypeScript type

## Test plan
- [ ] Migration SQL is valid
- [ ] `pnpm typecheck` passes
- [ ] `getCDRDataHolders()` returns fallbacks when CDR Register unavailable

Closes #135