### PR TITLE
CA-3: OzBargain LLM parser — replace regex with Claude Haiku extraction

### DIFF
--- a/app/src/app/api/cron/ozbargain-parse/route.ts
+++ b/app/src/app/api/cron/ozbargain-parse/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { parseOzBargainFeed, type OzBargainFeedItem } from '@/lib/ozbargain-parser'
+
+const OZBARGAIN_RSS_URL = 'https://www.ozbargain.com.au/deals/feed'
+
+async function fetchOzBargainFeed(): Promise<OzBargainFeedItem[]> {
+  const response = await fetch(OZBARGAIN_RSS_URL, {
+    headers: { 'User-Agent': 'RewardRelay/1.0' },
+    signal: AbortSignal.timeout(15000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`OzBargain feed returned ${response.status}`)
+  }
+
+  const xml = await response.text()
+  const items: OzBargainFeedItem[] = []
+
+  // Simple XML parsing for RSS feed
+  const itemMatches = xml.matchAll(/<item>([\s\S]*?)<\/item>/g)
+  for (const match of itemMatches) {
+    const itemXml = match[1]
+    const title = itemXml.match(/<title><!\[CDATA\[(.*?)\]\]><\/title>/)?.[1] ?? itemXml.match(/<title>(.*?)<\/title>/)?.[1] ?? ''
+    const description = itemXml.match(/<description><!\[CDATA\[([\s\S]*?)\]\]><\/description>/)?.[1] ?? itemXml.match(/<description>([\s\S]*?)<\/description>/)?.[1] ?? ''
+    const link = itemXml.match(/<link>(.*?)<\/link>/)?.[1] ?? ''
+    const pubDate = itemXml.match(/<pubDate>(.*?)<\/pubDate>/)?.[1] ?? ''
+
+    if (title) {
+      items.push({ title, description, link, pubDate })
+    }
+  }
+
+  return items
+}
+
+export async function POST(request: NextRequest) {
+  // Verify cron secret
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_KEY!
+  )
+
+  try {
+    // Fetch OzBargain RSS feed
+    const feedItems = await fetchOzBargainFeed()
+    console.log(`Fetched ${feedItems.length} OzBargain items`)
+
+    // Parse with Claude Haiku
+    const parsedOffers = await parseOzBargainFeed(feedItems)
+    console.log(`Parsed ${parsedOffers.length} bonus offers`)
+
+    let matched = 0
+    let unmatched = 0
+
+    // Fuzzy match against cards table
+    for (const { offer } of parsedOffers) {
+      // Try to match issuer + card name to existing cards
+      const { data: matchedCards } = await supabase
+        .from('cards')
+        .select('id, name, bank, welcome_bonus_points, offer_expiry_date')
+        .ilike('bank', `%${offer.issuer}%`)
+        .limit(10)
+
+      let cardMatch = null
+      if (matchedCards && matchedCards.length > 0) {
+        if (offer.cardName) {
+          cardMatch = matchedCards.find(
+            (c) =>
+              c.name.toLowerCase().includes(offer.cardName!.toLowerCase()) ||
+              offer.cardName!.toLowerCase().includes(c.name.toLowerCase())
+          )
+        }
+        if (!cardMatch) cardMatch = matchedCards[0]
+      }
+
+      if (cardMatch) {
+        // Only update if the offer is newer or has more points
+        const shouldUpdate =
+          !cardMatch.welcome_bonus_points ||
+          offer.bonusPoints > cardMatch.welcome_bonus_points
+
+        if (shouldUpdate) {
+          await supabase
+            .from('cards')
+            .update({
+              welcome_bonus_points: offer.bonusPoints,
+              bonus_spend_requirement: offer.spendRequirement,
+              ...(offer.expiryDate && { offer_expiry_date: offer.expiryDate }),
+              last_verified_at: new Date().toISOString(),
+            })
+            .eq('id', cardMatch.id)
+        }
+        matched++
+      } else {
+        console.log(`Unmatched offer: ${offer.issuer} - ${offer.cardName ?? 'unknown card'} (${offer.bonusPoints} ${offer.programName})`)
+        unmatched++
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      feedItems: feedItems.length,
+      parsedOffers: parsedOffers.length,
+      matched,
+      unmatched,
+    })
+  } catch (error) {
+    console.error('OzBargain parse cron error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error', details: String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/app/src/lib/ozbargain-parser.ts
+++ b/app/src/lib/ozbargain-parser.ts
@@ -1,0 +1,86 @@
+import Anthropic from '@anthropic-ai/sdk'
+
+const anthropic = new Anthropic()
+
+export interface BonusOffer {
+  issuer: string
+  cardName: string | null
+  bonusPoints: number
+  programName: string
+  spendRequirement: number
+  timeframeMonths: number
+  annualFee: number | null
+  expiryDate: string | null
+}
+
+const OZBARGAIN_SYSTEM_PROMPT = `Extract credit card sign-up bonus offer details from OzBargain deal. Return null via tool if not a credit card bonus offer.`
+
+export async function parseOzBargainDeal(
+  title: string,
+  description: string
+): Promise<BonusOffer | null> {
+  try {
+    const response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 256,
+      system: OZBARGAIN_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: `Title: ${title}\nDescription: ${description}`,
+        },
+      ],
+      tools: [
+        {
+          name: 'extract_bonus_offer',
+          description: 'Extract credit card bonus offer details from an OzBargain deal',
+          input_schema: {
+            type: 'object' as const,
+            properties: {
+              issuer: { type: 'string', description: 'Bank or card issuer name' },
+              cardName: { type: ['string', 'null'] as ('string' | 'null')[], description: 'Specific card name if mentioned' },
+              bonusPoints: { type: 'number', description: 'Number of bonus points offered' },
+              programName: { type: 'string', description: 'Loyalty program name (e.g. Qantas Points, Velocity Points)' },
+              spendRequirement: { type: 'number', description: 'Minimum spend required in AUD' },
+              timeframeMonths: { type: 'number', description: 'Timeframe to meet spend requirement in months' },
+              annualFee: { type: ['number', 'null'] as ('number' | 'null')[], description: 'Annual fee in AUD if mentioned' },
+              expiryDate: { type: ['string', 'null'] as ('string' | 'null')[], description: 'Offer expiry date in ISO format if mentioned' },
+            },
+            required: ['issuer', 'bonusPoints', 'programName', 'spendRequirement', 'timeframeMonths'],
+          },
+        },
+      ],
+      tool_choice: { type: 'tool', name: 'extract_bonus_offer' },
+    })
+
+    const toolUse = response.content.find((b) => b.type === 'tool_use')
+    if (!toolUse || toolUse.type !== 'tool_use') return null
+
+    return toolUse.input as BonusOffer
+  } catch (error) {
+    console.error('OzBargain parse error:', error)
+    return null
+  }
+}
+
+export interface OzBargainFeedItem {
+  title: string
+  description: string
+  link: string
+  pubDate: string
+}
+
+export async function parseOzBargainFeed(
+  feedItems: OzBargainFeedItem[]
+): Promise<Array<{ offer: BonusOffer; link: string; pubDate: string }>> {
+  const results: Array<{ offer: BonusOffer; link: string; pubDate: string }> = []
+
+  for (const item of feedItems) {
+    const offer = await parseOzBargainDeal(item.title, item.description)
+    if (offer) {
+      results.push({ offer, link: item.link, pubDate: item.pubDate })
+    }
+  }
+
+  return results
+}

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -10,6 +10,7 @@
     { "path": "/api/cron/loyalty-expiry",  "schedule": "0 22 * * *" },
     { "path": "/api/cron/deals-sync",      "schedule": "0 6 * * *"  },
     { "path": "/api/cron/deal-alerts",     "schedule": "0 23 * * *" },
-    { "path": "/api/cron/leaderboard",     "schedule": "0 0 * * *"  }
+    { "path": "/api/cron/leaderboard",     "schedule": "0 0 * * *"  },
+    { "path": "/api/cron/ozbargain-parse", "schedule": "0 */6 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary
- Replaces CSS/regex OzBargain parsing with Claude Haiku tool use extraction
- Adds `parseOzBargainDeal()` using `extract_bonus_offer` tool schema
- Fuzzy matches extracted offers against existing cards table (ILIKE)
- Adds `/api/cron/ozbargain-parse` route running every 6 hours

## Test plan
- [ ] Parser returns structured offers from OzBargain RSS
- [ ] Fuzzy match works for known AU card names
- [ ] `pnpm typecheck` passes

Closes #137