### PR TITLE
CA-2: CDR bank fetcher + weekly cron to upsert all bank products

### DIFF
--- a/app/src/app/api/cron/cdr-refresh/route.ts
+++ b/app/src/app/api/cron/cdr-refresh/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { fetchAllBanksCDRProducts } from '@/lib/cdr/fetcher'
+import type { Database } from '@/types/database.types'
+
+type CdrProductInsert = Database['public']['Tables']['cdr_products']['Insert']
+
+export async function POST(request: NextRequest) {
+  // Verify cron secret
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_KEY!
+  )
+
+  const startTime = Date.now()
+  let totalUpserted = 0
+  let totalFailed = 0
+  const bankSummary: Array<{ bank: string; upserted: number; error?: string }> = []
+
+  try {
+    const bankResults = await fetchAllBanksCDRProducts()
+
+    for (const { bankSlug, products, error } of bankResults) {
+      if (error || products.length === 0) {
+        bankSummary.push({ bank: bankSlug, upserted: 0, error: error ?? 'No products found' })
+        totalFailed++
+        continue
+      }
+
+      // Upsert in batches of 50
+      const batchSize = 50
+      let bankUpserted = 0
+
+      for (let i = 0; i < products.length; i += batchSize) {
+        const batch = products.slice(i, i + batchSize)
+
+        const { error: upsertError } = await supabase
+          .from('cdr_products')
+          .upsert(batch as CdrProductInsert[], {
+            onConflict: 'bank_slug,product_id',
+          })
+
+        if (upsertError) {
+          console.error(`Upsert error for ${bankSlug}:`, upsertError)
+        } else {
+          bankUpserted += batch.length
+        }
+      }
+
+      // Mark products not in this refresh as inactive for this bank
+      if (products.length > 0) {
+        const activeProductIds = products.map((p) => p.product_id)
+        await supabase
+          .from('cdr_products')
+          .update({ is_active: false })
+          .eq('bank_slug', bankSlug)
+          .not('product_id', 'in', `(${activeProductIds.map((id) => `"${id}"`).join(',')})`)
+      }
+
+      totalUpserted += bankUpserted
+      bankSummary.push({ bank: bankSlug, upserted: bankUpserted })
+    }
+
+    return NextResponse.json({
+      success: true,
+      totalUpserted,
+      totalFailed,
+      durationMs: Date.now() - startTime,
+      banks: bankSummary,
+    })
+  } catch (error) {
+    console.error('CDR refresh cron error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error', details: String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/app/src/lib/cdr/fetcher.ts
+++ b/app/src/lib/cdr/fetcher.ts
@@ -1,0 +1,192 @@
+import { getCDRDataHolders, type CDRDataHolder } from './register'
+import type { Database, Json } from '@/types/database.types'
+
+type CdrProductInsert = Database['public']['Tables']['cdr_products']['Insert']
+
+// CDR product API response types
+interface CDRFee {
+  feeType: string
+  name: string
+  amount?: string
+  currency?: string
+  additionalValue?: string
+  additionalInfo?: string
+}
+
+interface CDRFeature {
+  featureType: string
+  additionalValue?: string
+  additionalInfo?: string
+}
+
+interface CDRLendingRate {
+  lendingRateType: string
+  rate: string
+  additionalValue?: string
+}
+
+interface CDRProductDetail {
+  productId: string
+  name: string
+  description?: string
+  brand?: string
+  brandName?: string
+  effectiveFrom?: string
+  productCategory?: string
+  fees?: CDRFee[]
+  features?: CDRFeature[]
+  lendingRates?: CDRLendingRate[]
+  eligibility?: Array<{ eligibilityType: string; additionalValue?: string }>
+}
+
+interface CDRProductsResponse {
+  data?: {
+    products?: CDRProductDetail[]
+  }
+  links?: {
+    next?: string
+  }
+}
+
+export interface ExtractedAnnualFee {
+  amount: number
+  waiver: string | null
+}
+
+export function extractAnnualFee(product: CDRProductDetail): ExtractedAnnualFee | null {
+  if (!product.fees || product.fees.length === 0) return null
+
+  // Find annual fee: additionalValue='P1Y' (ISO 8601 duration = 1 year) or name contains 'annual'
+  const annualFee = product.fees.find(
+    (fee) =>
+      fee.additionalValue === 'P1Y' ||
+      fee.name.toLowerCase().includes('annual') ||
+      fee.name.toLowerCase().includes('yearly')
+  )
+
+  if (!annualFee || !annualFee.amount) return null
+
+  const amount = parseFloat(annualFee.amount)
+  if (isNaN(amount)) return null
+
+  return {
+    amount,
+    waiver: annualFee.additionalInfo ?? null,
+  }
+}
+
+export function extractLoyaltyProgram(product: CDRProductDetail): string | null {
+  if (!product.features) return null
+
+  const loyaltyFeature = product.features.find(
+    (f) => f.featureType === 'LOYALTY_PROGRAM'
+  )
+
+  return loyaltyFeature?.additionalValue ?? null
+}
+
+export function extractPurchaseRate(product: CDRProductDetail): number | null {
+  if (!product.lendingRates) return null
+
+  const purchaseRate = product.lendingRates.find(
+    (r) => r.lendingRateType === 'PURCHASE'
+  )
+
+  if (!purchaseRate?.rate) return null
+
+  const rate = parseFloat(purchaseRate.rate)
+  return isNaN(rate) ? null : rate
+}
+
+export function extractMinCreditLimit(product: CDRProductDetail): number | null {
+  if (!product.eligibility) return null
+
+  const minCreditLimit = product.eligibility.find(
+    (e) => e.eligibilityType === 'MIN_LIMIT'
+  )
+
+  if (!minCreditLimit?.additionalValue) return null
+
+  const limit = parseFloat(minCreditLimit.additionalValue)
+  return isNaN(limit) ? null : limit
+}
+
+export async function fetchBankCDRProducts(
+  bankSlug: string,
+  baseUrl: string
+): Promise<CdrProductInsert[]> {
+  // Strip trailing /cds-au/v1/banking if already included in baseUrl
+  const cleanBase = baseUrl.replace(/\/cds-au\/v1\/banking\/?$/, '')
+  const url = `${cleanBase}/cds-au/v1/banking/products?product-category=CRED_AND_CHRG_CARDS&page-size=100`
+
+  const response = await fetch(url, {
+    headers: {
+      'x-v': '4',
+      'x-min-v': '3',
+      'Accept': 'application/json',
+    },
+    signal: AbortSignal.timeout(20000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`CDR API returned ${response.status} for ${bankSlug}: ${url}`)
+  }
+
+  const data = await response.json() as CDRProductsResponse
+  const products = data.data?.products ?? []
+
+  return products.map((product): CdrProductInsert => {
+    const annualFeeData = extractAnnualFee(product)
+    const loyaltyProgram = extractLoyaltyProgram(product)
+    const purchaseRate = extractPurchaseRate(product)
+    const minCreditLimit = extractMinCreditLimit(product)
+
+    return {
+      product_id: product.productId,
+      bank_slug: bankSlug,
+      bank_name: product.brandName ?? product.brand ?? bankSlug,
+      product_name: product.name,
+      product_category: product.productCategory ?? 'CRED_AND_CHRG_CARDS',
+      annual_fee_amount: annualFeeData?.amount ?? null,
+      annual_fee_waiver_condition: annualFeeData?.waiver ?? null,
+      loyalty_program_name: loyaltyProgram,
+      purchase_rate: purchaseRate,
+      min_credit_limit: minCreditLimit,
+      raw_json: product as unknown as Json,
+      cdr_effective_from: product.effectiveFrom ?? null,
+      last_fetched_at: new Date().toISOString(),
+      is_active: true,
+    }
+  })
+}
+
+export async function fetchAllBanksCDRProducts(): Promise<{
+  bankSlug: string
+  products: CdrProductInsert[]
+  error?: string
+}[]> {
+  let holders: CDRDataHolder[]
+  try {
+    holders = await getCDRDataHolders()
+  } catch (error) {
+    console.error('Failed to get CDR data holders:', error)
+    return []
+  }
+
+  const results = await Promise.allSettled(
+    holders.map(async (holder) => {
+      const products = await fetchBankCDRProducts(holder.bankSlug, holder.publicBaseUri)
+      return { bankSlug: holder.bankSlug, products }
+    })
+  )
+
+  return results.map((result, i) => {
+    const holder = holders[i]!
+    if (result.status === 'fulfilled') {
+      return result.value
+    } else {
+      console.warn(`CDR fetch failed for ${holder.bankSlug}:`, result.reason)
+      return { bankSlug: holder.bankSlug, products: [], error: String(result.reason) }
+    }
+  })
+}

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -11,6 +11,7 @@
     { "path": "/api/cron/deals-sync",      "schedule": "0 6 * * *"  },
     { "path": "/api/cron/deal-alerts",     "schedule": "0 23 * * *" },
     { "path": "/api/cron/leaderboard",     "schedule": "0 0 * * *"  },
-    { "path": "/api/cron/ozbargain-parse", "schedule": "0 */6 * * *" }
+    { "path": "/api/cron/ozbargain-parse", "schedule": "0 */6 * * *" },
+    { "path": "/api/cron/cdr-refresh",     "schedule": "0 16 * * 0" }
   ]
 }


### PR DESCRIPTION
## Summary
- Implements `fetchBankCDRProducts(bankSlug, baseUrl)` that fetches credit card products from CDR APIs
- Extracts annual fees (via P1Y duration code), loyalty programs, purchase rates from CDR JSON
- Adds `POST /api/cron/cdr-refresh` with CRON_SECRET auth — iterates all CDR data holders and upserts products in batches of 50
- Registers weekly cron in vercel.json (Sundays 16:00 UTC = Monday 2am AEST)
- Failed bank fetches log warning and continue (don't abort the full run)

## Test plan
- [ ] Cron route returns 200 with bank summary
- [ ] Failed banks are logged but don't crash the run
- [ ] `pnpm typecheck` passes

Closes #136