### PR TITLE
CA-7: CDR x LLM reconciliation + conflict detection

### DIFF
--- a/app/src/app/api/cron/card-extract/route.ts
+++ b/app/src/app/api/cron/card-extract/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { fetchCardPageByUrl } from '@/lib/card-fetcher'
+import { extractCardData, getVerificationAction } from '@/lib/card-extractor'
+import { reconcileCardData, type CdrProduct } from '@/lib/cdr/reconcile'
+import type { Database } from '@/types/database.types'
+
+type Card = Database['public']['Tables']['cards']['Row']
+
+async function processCard(
+  card: Card,
+  supabase: ReturnType<typeof createClient<Database>>
+): Promise<{ cardId: string; success: boolean; error?: string }> {
+  const cardId = card.id
+
+  try {
+    const cardUrl = card.application_link
+    if (!cardUrl) {
+      return { cardId, success: false, error: 'No application_link' }
+    }
+
+    // Fetch page content
+    const { markdown } = await fetchCardPageByUrl(cardUrl)
+
+    // Get CDR data for this bank if available
+    let cdrData: CdrProduct | undefined
+    const bankSlug = card.bank?.toLowerCase().replace(/\s+/g, '-') ?? ''
+    if (bankSlug) {
+      const { data: cdrProducts } = await supabase
+        .from('cdr_products')
+        .select('id, product_id, bank_slug, bank_name, product_name, annual_fee_amount, loyalty_program_name, is_active')
+        .eq('bank_slug', bankSlug)
+        .eq('is_active', true)
+        .ilike('product_name', `%${card.name.split(' ').slice(0, 2).join(' ')}%`)
+        .limit(1)
+
+      if (cdrProducts && cdrProducts.length > 0) {
+        cdrData = cdrProducts[0] as CdrProduct
+      }
+    }
+
+    // Extract card data with Claude
+    const extracted = await extractCardData(markdown, cdrData)
+
+    // Reconcile with CDR data
+    const reconciled = cdrData
+      ? reconcileCardData(cdrData, extracted)
+      : { conflicts: [], resolvedAnnualFee: null, requiresReview: false, isDiscontinued: false }
+
+    // Determine verification action
+    const verificationAction = getVerificationAction(extracted.confidenceScore)
+
+    const updateData: Database['public']['Tables']['cards']['Update'] = {
+      needs_verification: verificationAction.needsVerification || reconciled.requiresReview,
+      verification_priority: verificationAction.verificationPriority,
+      last_verified_at: new Date().toISOString(),
+    }
+
+    if (reconciled.resolvedAnnualFee !== null) {
+      updateData.annual_fee = reconciled.resolvedAnnualFee
+    }
+
+    if (reconciled.isDiscontinued) {
+      updateData.is_active = false
+    }
+
+    await supabase.from('cards').update(updateData).eq('id', cardId)
+
+    console.log(
+      `Extracted ${card.name}: confidence=${extracted.confidenceScore.toFixed(2)}, conflicts=${reconciled.conflicts.length}`
+    )
+
+    return { cardId, success: true }
+  } catch (error) {
+    console.error(`Failed to process card ${cardId}:`, error)
+    return { cardId, success: false, error: String(error) }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_KEY!
+  )
+
+  const startTime = Date.now()
+
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+
+  const { data: cards, error } = await supabase
+    .from('cards')
+    .select('*')
+    .eq('is_active', true)
+    .or(`needs_verification.eq.true,last_verified_at.is.null,last_verified_at.lt.${sevenDaysAgo}`)
+    .not('application_link', 'is', null)
+    .limit(50)
+
+  if (error) {
+    return NextResponse.json({ error: 'DB error', details: error.message }, { status: 500 })
+  }
+
+  if (!cards || cards.length === 0) {
+    return NextResponse.json({ success: true, processed: 0, message: 'No cards need extraction' })
+  }
+
+  const batchSize = 10
+  const results: Array<{ cardId: string; success: boolean; error?: string }> = []
+
+  for (let i = 0; i < cards.length; i += batchSize) {
+    const batch = cards.slice(i, i + batchSize)
+    const batchResults = await Promise.all(
+      batch.map((card) => processCard(card, supabase))
+    )
+    results.push(...batchResults)
+  }
+
+  const succeeded = results.filter((r) => r.success).length
+  const failed = results.filter((r) => !r.success).length
+
+  return NextResponse.json({
+    success: true,
+    processed: results.length,
+    succeeded,
+    failed,
+    durationMs: Date.now() - startTime,
+  })
+}

--- a/app/src/lib/cdr/reconcile.ts
+++ b/app/src/lib/cdr/reconcile.ts
@@ -1,6 +1,5 @@
 import type { ExtractedCard } from '@/types/extraction'
 
-// Placeholder — full implementation in CA-7
 export interface CdrProduct {
   id: string
   product_id: string
@@ -26,16 +25,72 @@ export interface ReconciliationResult {
   isDiscontinued: boolean
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function reconcileCardData(
-  _cdrProduct: CdrProduct,
-  _extractedCard: ExtractedCard
+  cdrProduct: CdrProduct,
+  extractedCard: ExtractedCard
 ): ReconciliationResult {
-  // Placeholder implementation — CA-7 will complete this
+  const conflicts: Conflict[] = []
+  let resolvedAnnualFee: number | null = null
+  let requiresReview = false
+
+  // Check if product is discontinued in CDR
+  const isDiscontinued = cdrProduct.is_active === false
+
+  // Annual fee reconciliation
+  if (cdrProduct.annual_fee_amount !== null && extractedCard.annualFee?.amount !== undefined) {
+    const cdrFee = cdrProduct.annual_fee_amount
+    const extractedFee = extractedCard.annualFee.amount
+    const difference = Math.abs(cdrFee - extractedFee)
+
+    if (difference > 10) {
+      // Significant discrepancy — flag as conflict
+      conflicts.push({
+        field: 'annualFee',
+        cdrValue: cdrFee,
+        extractedValue: extractedFee,
+        difference,
+      })
+      requiresReview = true
+      console.warn(
+        `Annual fee conflict for ${cdrProduct.product_name}: CDR=$${cdrFee}, LLM=$${extractedFee} (diff=$${difference})`
+      )
+    } else {
+      // Within tolerance — use CDR value as authoritative
+      resolvedAnnualFee = cdrFee
+    }
+  } else if (cdrProduct.annual_fee_amount !== null) {
+    // CDR has fee but LLM didn't extract it — use CDR
+    resolvedAnnualFee = cdrProduct.annual_fee_amount
+  } else if (extractedCard.annualFee?.amount !== undefined) {
+    // No CDR data — use LLM extracted value
+    resolvedAnnualFee = extractedCard.annualFee.amount
+  }
+
+  // Loyalty program name check (informational only, no conflict flagging)
+  if (
+    cdrProduct.loyalty_program_name &&
+    extractedCard.earnRates?.length > 0
+  ) {
+    const extractedPrograms = extractedCard.earnRates.map((r) =>
+      r.programName.toLowerCase()
+    )
+    const cdrProgram = cdrProduct.loyalty_program_name.toLowerCase()
+    const programMatches = extractedPrograms.some(
+      (p) => p.includes(cdrProgram) || cdrProgram.includes(p)
+    )
+    if (!programMatches) {
+      conflicts.push({
+        field: 'loyaltyProgram',
+        cdrValue: cdrProduct.loyalty_program_name,
+        extractedValue: extractedCard.earnRates[0]?.programName ?? null,
+      })
+    }
+  }
+
   return {
-    conflicts: [],
-    resolvedAnnualFee: null,
-    requiresReview: false,
-    isDiscontinued: false,
+    conflicts,
+    resolvedAnnualFee,
+    requiresReview: requiresReview || isDiscontinued,
+    isDiscontinued,
   }
 }

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -12,6 +12,7 @@
     { "path": "/api/cron/deal-alerts",     "schedule": "0 23 * * *" },
     { "path": "/api/cron/leaderboard",     "schedule": "0 0 * * *"  },
     { "path": "/api/cron/ozbargain-parse", "schedule": "0 */6 * * *" },
-    { "path": "/api/cron/cdr-refresh",     "schedule": "0 16 * * 0" }
+    { "path": "/api/cron/cdr-refresh",     "schedule": "0 16 * * 0" },
+    { "path": "/api/cron/card-extract",    "schedule": "0 17 * * 0"  }
   ]
 }


### PR DESCRIPTION
## Summary
- Implements `reconcileCardData()` that compares CDR and LLM annual fee values
- Flags conflicts when difference > $10, auto-resolves within $10 using CDR as authoritative
- Detects discontinued products via CDR `is_active=false`
- Adds `POST /api/cron/card-extract` — processes cards needing verification with max 10 concurrent
- Registers weekly cron (Sunday 17:00 UTC = Monday 3am AEST)

## Test plan
- [ ] `reconcileCardData` correctly flags >$10 fee differences
- [ ] Cron route returns 200 with processed count
- [ ] `pnpm typecheck` passes

Closes #141