### PR TITLE
CA-8: Change hash system + extraction_log table

### DIFF
--- a/app/src/lib/change-hash.ts
+++ b/app/src/lib/change-hash.ts
@@ -1,0 +1,53 @@
+import { createHash } from 'crypto'
+import type { EarnRate } from '@/types/extraction'
+
+export interface HashableCard {
+  annualFee: number
+  earnRates: Pick<EarnRate, 'category' | 'pointsPerDollar'>[]
+  bonusPoints: number
+  spendReq: number
+}
+
+export function computeChangeHash(card: HashableCard): string {
+  // Sort earn rates by category for deterministic ordering
+  const sortedEarnRates = [...card.earnRates].sort((a, b) =>
+    a.category.localeCompare(b.category)
+  )
+
+  const canonical = {
+    annualFee: card.annualFee,
+    earnRates: sortedEarnRates.map((r) => ({
+      cat: r.category,
+      ppd: r.pointsPerDollar,
+    })),
+    bonusPoints: card.bonusPoints,
+    spendReq: card.spendReq,
+  }
+
+  return createHash('sha256')
+    .update(JSON.stringify(canonical))
+    .digest('hex')
+    .slice(0, 16)
+}
+
+export interface HashComparisonResult {
+  newHash: string
+  hasChanged: boolean
+  shouldScheduleValidation: boolean
+}
+
+export function compareHashes(
+  newHash: string,
+  storedHash: string | null,
+  lastExtractedAt: string | null
+): HashComparisonResult {
+  const hasChanged = storedHash !== null && newHash !== storedHash
+
+  // Schedule validation if same hash for 30+ days
+  const shouldScheduleValidation =
+    !hasChanged &&
+    lastExtractedAt !== null &&
+    Date.now() - new Date(lastExtractedAt).getTime() > 30 * 24 * 60 * 60 * 1000
+
+  return { newHash, hasChanged, shouldScheduleValidation }
+}

--- a/app/src/types/database.types.ts
+++ b/app/src/types/database.types.ts
@@ -515,13 +515,16 @@ export type Database = {
           bonus_spend_window_months: number | null
           bonus_structure: Json | null
           change_detected_at: string | null
+          change_hash: string | null
           created_at: string | null
           earn_rate_primary: number | null
           earn_rate_secondary: number | null
           eligibility_restriction_months: number | null
+          extraction_confidence: number | null
           first_card_only: boolean | null
           id: string
           is_active: boolean | null
+          last_extracted_at: string | null
           last_scraped_at: string | null
           last_verified_at: string | null
           min_income: number | null
@@ -547,13 +550,16 @@ export type Database = {
           bonus_spend_window_months?: number | null
           bonus_structure?: Json | null
           change_detected_at?: string | null
+          change_hash?: string | null
           created_at?: string | null
           earn_rate_primary?: number | null
           earn_rate_secondary?: number | null
           eligibility_restriction_months?: number | null
+          extraction_confidence?: number | null
           first_card_only?: boolean | null
           id?: string
           is_active?: boolean | null
+          last_extracted_at?: string | null
           last_scraped_at?: string | null
           last_verified_at?: string | null
           min_income?: number | null
@@ -579,13 +585,16 @@ export type Database = {
           bonus_spend_window_months?: number | null
           bonus_structure?: Json | null
           change_detected_at?: string | null
+          change_hash?: string | null
           created_at?: string | null
           earn_rate_primary?: number | null
           earn_rate_secondary?: number | null
           eligibility_restriction_months?: number | null
+          extraction_confidence?: number | null
           first_card_only?: boolean | null
           id?: string
           is_active?: boolean | null
+          last_extracted_at?: string | null
           last_scraped_at?: string | null
           last_verified_at?: string | null
           min_income?: number | null
@@ -603,6 +612,53 @@ export type Database = {
           welcome_bonus_points?: number | null
         }
         Relationships: []
+      }
+      extraction_log: {
+        Row: {
+          id: string
+          card_id: string | null
+          run_at: string | null
+          model_used: string | null
+          confidence_score: number | null
+          change_hash: string | null
+          hash_changed: boolean | null
+          conflicts_detected: Json | null
+          raw_output: Json | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          card_id?: string | null
+          run_at?: string | null
+          model_used?: string | null
+          confidence_score?: number | null
+          change_hash?: string | null
+          hash_changed?: boolean | null
+          conflicts_detected?: Json | null
+          raw_output?: Json | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          card_id?: string | null
+          run_at?: string | null
+          model_used?: string | null
+          confidence_score?: number | null
+          change_hash?: string | null
+          hash_changed?: boolean | null
+          conflicts_detected?: Json | null
+          raw_output?: Json | null
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "extraction_log_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
+          }
+        ]
       }
       daily_insights: {
         Row: {
@@ -1062,6 +1118,44 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      }
+      card_corrections: {
+        Row: {
+          id: string
+          card_id: string | null
+          field: string
+          reported_value: string
+          reported_by: string | null
+          status: 'pending' | 'verified' | 'dismissed' | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          card_id?: string | null
+          field: string
+          reported_value: string
+          reported_by?: string | null
+          status?: 'pending' | 'verified' | 'dismissed' | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          card_id?: string | null
+          field?: string
+          reported_value?: string
+          reported_by?: string | null
+          status?: 'pending' | 'verified' | 'dismissed' | null
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "card_corrections_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       cdr_products: {
         Row: {

--- a/app/supabase/migrations/20260317231943_add_extraction_tracking.sql
+++ b/app/supabase/migrations/20260317231943_add_extraction_tracking.sql
@@ -1,0 +1,32 @@
+-- Add extraction tracking columns to cards table
+ALTER TABLE cards
+  ADD COLUMN IF NOT EXISTS change_hash text,
+  ADD COLUMN IF NOT EXISTS last_extracted_at timestamptz,
+  ADD COLUMN IF NOT EXISTS extraction_confidence numeric;
+
+-- Create extraction_log table for audit trail
+CREATE TABLE IF NOT EXISTS extraction_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  card_id uuid REFERENCES cards(id) ON DELETE CASCADE,
+  run_at timestamptz DEFAULT now(),
+  model_used text,
+  confidence_score numeric,
+  change_hash text,
+  hash_changed boolean DEFAULT false,
+  conflicts_detected jsonb DEFAULT '[]'::jsonb,
+  raw_output jsonb,
+  created_at timestamptz DEFAULT now()
+);
+
+-- RLS for extraction_log
+ALTER TABLE extraction_log ENABLE ROW LEVEL SECURITY;
+
+-- Service role manages all
+GRANT ALL ON extraction_log TO service_role;
+
+-- Index for efficient querying
+CREATE INDEX IF NOT EXISTS idx_extraction_log_card_id ON extraction_log(card_id);
+CREATE INDEX IF NOT EXISTS idx_extraction_log_run_at ON extraction_log(run_at DESC);
+
+-- Index for cards needing re-extraction (30+ days since last extraction)
+CREATE INDEX IF NOT EXISTS idx_cards_last_extracted_at ON cards(last_extracted_at);


### PR DESCRIPTION
## Summary
- `computeChangeHash()` produces deterministic 16-char SHA-256 from annual fee, earn rates, bonus data
- Earn rates sorted by category before hashing for deterministic output
- `compareHashes()` detects data changes and flags 30-day stale data for re-validation
- Migration adds `change_hash`, `last_extracted_at`, `extraction_confidence` to cards table
- New `extraction_log` table tracks every extraction run with model, confidence, hash delta

## Test plan
- [ ] Same input always produces same hash (deterministic)
- [ ] Different input produces different hash
- [ ] Migration SQL is valid
- [ ] `pnpm typecheck` passes

Closes #142