### PR TITLE
feat(design): implement Financial Luminary tokens + AppShell nav

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Inter:wght@400;500;600&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "../styles/tokens.css";
@@ -111,12 +112,12 @@
   }
 
   html {
-    /* Smooth color transitions when theme changes */
-    color-scheme: light dark;
+    color-scheme: dark;
   }
 
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-body, 'Inter', sans-serif);
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
@@ -191,6 +192,31 @@
   }
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
+  }
+
+  /* Glassmorphism utilities */
+  .glass {
+    background: rgba(27, 31, 44, 0.6);
+    backdrop-filter: blur(20px);
+  }
+  .glass-card {
+    background: rgba(27, 31, 44, 0.4);
+    backdrop-filter: blur(24px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .glass-panel {
+    background: rgba(255, 255, 255, 0.03);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+  .arc-glow {
+    filter: drop-shadow(0 0 8px rgba(78, 222, 163, 0.4));
+  }
+  .premium-glow {
+    box-shadow: 0 0 20px rgba(78, 222, 163, 0.15), inset 0 0 10px rgba(78, 222, 163, 0.05);
+  }
+  .tabular {
+    font-variant-numeric: tabular-nums;
   }
 }
 

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -3,80 +3,28 @@
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { toast } from "sonner"
-import {
-  Home,
-  CreditCard,
-  LogOut,
-  Sparkles,
-  Wallet,
-  CalendarDays,
-  Compass,
-  ChevronRight,
-  TrendingUp,
-  Upload,
-  History,
-  Scale,
-  Lightbulb,
-  Calendar,
-} from "lucide-react"
-import { useMemo, useState } from "react"
+import { Home, CreditCard, Plane, BarChart2, Gift, User } from "lucide-react"
+import { useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase/client"
-
-type NavChild = {
-  href: string
-  label: string
-  icon: React.ComponentType<{ className?: string }>
-}
 
 type NavItem = {
   href: string
   label: string
   icon: React.ComponentType<{ className?: string }>
-  children?: NavChild[]
+  desktopOnly?: boolean
 }
 
 const navItems: NavItem[] = [
-  {
-    href: "/dashboard",
-    label: "Home",
-    icon: Home,
-  },
-  {
-    href: "/cards",
-    label: "Cards",
-    icon: CreditCard,
-  },
-  {
-    href: "/recommendations",
-    label: "Discover",
-    icon: Compass,
-    children: [
-      { href: "/recommendations", label: "Recommendations", icon: Lightbulb },
-      { href: "/compare", label: "Compare", icon: Scale },
-      { href: "/projections", label: "Projections", icon: TrendingUp },
-    ],
-  },
-  {
-    href: "/spending",
-    label: "Spending",
-    icon: Wallet,
-    children: [
-      { href: "/spending", label: "Tracker", icon: Wallet },
-      { href: "/statements", label: "Import Statements", icon: Upload },
-    ],
-  },
-  {
-    href: "/calendar",
-    label: "Timeline",
-    icon: CalendarDays,
-    children: [
-      { href: "/calendar", label: "Calendar", icon: Calendar },
-      { href: "/history", label: "History", icon: History },
-    ],
-  },
+  { href: "/dashboard", label: "Home", icon: Home },
+  { href: "/cards", label: "Cards", icon: CreditCard },
+  { href: "/projections", label: "Flights", icon: Plane },
+  { href: "/spending", label: "Track", icon: BarChart2 },
+  { href: "/recommendations", label: "Redeem", icon: Gift },
+  { href: "/account", label: "Account", icon: User, desktopOnly: true },
 ]
+
+const mobileItems = navItems.filter((item) => !item.desktopOnly)
 
 type AppShellProps = {
   children: React.ReactNode
@@ -86,23 +34,6 @@ export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname()
   const router = useRouter()
   const [signingOut, setSigningOut] = useState(false)
-
-  const navMap = useMemo(() => {
-    return navItems.map((item) => {
-      const isParentActive = pathname.startsWith(item.href)
-      const isChildActive = item.children?.some((c) => pathname.startsWith(c.href)) ?? false
-      const active = isParentActive || isChildActive
-
-      return {
-        ...item,
-        active,
-        children: item.children?.map((child) => ({
-          ...child,
-          active: pathname.startsWith(child.href),
-        })),
-      }
-    })
-  }, [pathname])
 
   const handleSignOut = async () => {
     setSigningOut(true)
@@ -115,126 +46,106 @@ export function AppShell({ children }: AppShellProps) {
     router.replace("/")
   }
 
-  return (
-    <div className="min-h-screen bg-[var(--surface-muted)]">
-      {/* Header */}
-      <header className="sticky top-0 z-20 border-b border-[var(--border-default)] bg-[var(--surface)]/90 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-3">
-          <Link href="/dashboard" className="flex items-center gap-2.5">
-            <div
-              className="flex h-8 w-8 items-center justify-center rounded-xl text-white shadow-sm"
-              style={{ background: "var(--gradient-cta)" }}
-            >
-              <Sparkles className="h-4 w-4" />
-            </div>
-            <span className="text-sm font-semibold text-[var(--text-primary)]">Reward Relay</span>
-          </Link>
+  const isActive = (href: string) => pathname.startsWith(href)
 
-          <div className="ml-auto flex items-center gap-2">
-            <Button
-              size="sm"
-              className="hidden rounded-full text-white shadow-sm md:inline-flex"
-              style={{ background: "var(--gradient-cta)" }}
-              onClick={() => router.push("/cards")}
+  return (
+    <div className="min-h-screen" style={{ background: "var(--background)" }}>
+      {/* Desktop Sidebar */}
+      <aside
+        className="fixed left-0 top-0 hidden h-screen w-64 flex-col border-r border-white/5 md:flex"
+        style={{ background: "var(--surface-container-low)" }}
+      >
+        {/* Logo */}
+        <div className="px-6 py-6">
+          <Link href="/dashboard" className="block">
+            <div className="text-xl font-bold tracking-tighter" style={{ color: "var(--primary)" }}>
+              Reward Relay
+            </div>
+            <div
+              className="mt-0.5 text-[10px] font-semibold uppercase tracking-[0.2em]"
+              style={{ color: "#64748b" }}
             >
-              <CreditCard className="mr-1.5 h-3.5 w-3.5" />
-              Add card
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleSignOut}
-              disabled={signingOut}
-              className="text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-              title="Sign out"
-            >
-              <LogOut className="h-4 w-4" />
-            </Button>
-          </div>
+              The Financial Luminary
+            </div>
+          </Link>
         </div>
+
+        {/* Nav */}
+        <nav className="flex-1 space-y-1 px-3">
+          {navItems.map((item) => {
+            const Icon = item.icon
+            const active = isActive(item.href)
+
+            if (item.href === "/account") {
+              return (
+                <button
+                  key={item.href}
+                  onClick={signingOut ? undefined : handleSignOut}
+                  disabled={signingOut}
+                  className={`flex w-full items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors ${
+                    active
+                      ? "border border-white/5 text-[#4edea3]"
+                      : "text-slate-400 hover:bg-[#313442] hover:text-white"
+                  }`}
+                  style={active ? { background: "var(--surface-container)" } : undefined}
+                >
+                  <Icon className="h-4 w-4 flex-shrink-0" />
+                  <span className="flex-1 text-left">{item.label}</span>
+                </button>
+              )
+            }
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors ${
+                  active
+                    ? "border border-white/5 text-[#4edea3]"
+                    : "text-slate-400 hover:bg-[#313442] hover:text-white"
+                }`}
+                style={active ? { background: "var(--surface-container)" } : undefined}
+              >
+                <Icon className="h-4 w-4 flex-shrink-0" />
+                <span>{item.label}</span>
+              </Link>
+            )
+          })}
+        </nav>
+      </aside>
+
+      {/* Mobile Header */}
+      <header
+        className="sticky top-0 z-20 flex items-center px-4 py-3 md:hidden"
+        style={{ background: "var(--surface-container-low)" }}
+      >
+        <Link href="/dashboard" className="block">
+          <div className="text-base font-bold tracking-tighter" style={{ color: "var(--primary)" }}>
+            Reward Relay
+          </div>
+        </Link>
       </header>
 
-      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 px-4 py-6 pb-24 md:grid-cols-[220px_1fr] md:pb-6">
-        {/* Desktop Sidebar */}
-        <aside className="hidden h-fit md:block">
-          <nav className="rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-2 shadow-sm">
-            {navMap.map((item) => {
-              const Icon = item.icon
-              const hasChildren = !!(item.children && item.children.length > 0)
-              const showChildren = hasChildren && item.active
-
-              return (
-                <div key={item.href}>
-                  <Link
-                    href={item.href}
-                    className={`flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
-                      item.active
-                        ? "bg-[var(--surface-strong)] text-[var(--text-primary)]"
-                        : "text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)] hover:text-[var(--text-primary)]"
-                    }`}
-                  >
-                    <Icon
-                      className={`h-4 w-4 flex-shrink-0 ${
-                        item.active ? "text-[var(--accent)]" : ""
-                      }`}
-                    />
-                    <span className="flex-1">{item.label}</span>
-                    {hasChildren && (
-                      <ChevronRight
-                        className={`h-3.5 w-3.5 transition-transform ${
-                          item.active
-                            ? "rotate-90 text-[var(--text-secondary)]"
-                            : "text-[var(--text-secondary)]/40"
-                        }`}
-                      />
-                    )}
-                  </Link>
-
-                  {/* Sub-items: shown when parent is active */}
-                  {showChildren && item.children && (
-                    <div className="mb-1 ml-4 space-y-0.5 border-l border-[var(--border-default)] pl-2.5 pt-0.5">
-                      {item.children.map((child) => {
-                        const ChildIcon = child.icon
-                        return (
-                          <Link
-                            key={child.href}
-                            href={child.href}
-                            className={`flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition-colors ${
-                              child.active
-                                ? "bg-[var(--surface-strong)] font-medium text-[var(--text-primary)]"
-                                : "text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)] hover:text-[var(--text-primary)]"
-                            }`}
-                          >
-                            <ChildIcon className="h-3.5 w-3.5 flex-shrink-0" />
-                            {child.label}
-                          </Link>
-                        )
-                      })}
-                    </div>
-                  )}
-                </div>
-              )
-            })}
-          </nav>
-        </aside>
-
-        <main className="min-w-0 space-y-5">{children}</main>
+      {/* Main content */}
+      <div className="min-h-screen md:pl-64">
+        <main className="min-w-0 p-6 pb-24 md:pb-6">{children}</main>
       </div>
 
-      {/* Mobile Bottom Nav — exactly 5 items, no scroll */}
-      <nav className="fixed inset-x-0 bottom-0 z-20 border-t border-[var(--border-default)] bg-[var(--surface)]/95 backdrop-blur md:hidden">
-        <div className="mx-auto grid max-w-sm grid-cols-5 px-2 py-1">
-          {navMap.map((item) => {
+      {/* Mobile Bottom Nav */}
+      <nav
+        className="fixed inset-x-0 bottom-0 z-20 backdrop-blur md:hidden"
+        style={{ background: "var(--surface-container-low)" }}
+      >
+        <div className="grid grid-cols-5 px-2 py-1">
+          {mobileItems.map((item) => {
             const Icon = item.icon
+            const active = isActive(item.href)
             return (
               <button
                 key={item.href}
                 onClick={() => router.push(item.href)}
-                className={`flex flex-col items-center gap-1 rounded-lg px-1 py-2 transition-colors ${
-                  item.active
-                    ? "text-[var(--accent)]"
-                    : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-                }`}
+                className="flex flex-col items-center gap-1 rounded-lg px-1 py-2 transition-colors"
+                style={{ color: active ? "#4edea3" : "#94a3b8" }}
               >
                 <Icon className="h-5 w-5 flex-shrink-0" />
                 <span className="text-[10px] font-medium leading-tight">{item.label}</span>

--- a/app/src/components/ui/ProGate.tsx
+++ b/app/src/components/ui/ProGate.tsx
@@ -10,6 +10,17 @@ interface ProGateProps {
   feature: string
   children: ReactNode
   teaserText?: string
+  isPro?: boolean
+  previewRows?: number
+  requiredTier?: string
+}
+
+export function ProBadge() {
+  return (
+    <span className="ml-1.5 inline-flex items-center rounded-full bg-gradient-to-r from-teal-500/20 to-cyan-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-400 ring-1 ring-teal-400/30">
+      Pro
+    </span>
+  )
 }
 
 export function ProGate({ feature, children, teaserText }: ProGateProps) {

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -1,195 +1,96 @@
 /* =====================================================
    REWARD RELAY — Design Tokens
-   Color system: emerald green accent, neutral grays
+   Color system: Financial Luminary — dark-mode only
    ===================================================== */
 
-/* ─── LIGHT THEME (default) ─── */
 :root {
-  /* Surfaces — clean whites and light grays */
-  --surface: #ffffff;
-  --surface-muted: #f8fafc;
-  --surface-soft: #f1f5f9;
-  --surface-strong: #e2e8f0;
-  --surface-subtle: #cbd5e1;
+  /* ─── Surface hierarchy ─── */
+  --surface: #0f131f;
+  --surface-dim: #0f131f;
+  --surface-container-lowest: #0a0e1a;
+  --surface-container-low: #171b28;
+  --surface-container: #1b1f2c;
+  --surface-container-high: #262a37;
+  --surface-container-highest: #313442;
+  --surface-bright: #353946;
+  --background: #0f131f;
 
-  /* Text — near-black to mid-gray */
-  --text-primary: #0f172a;
-  --text-secondary: #64748b;
-  --text-inverse: #ffffff;
+  /* ─── Text ─── */
+  --on-surface: #dfe2f3;
+  --on-surface-variant: #bbcabf;
+  --on-background: #dfe2f3;
 
-  /* Accent — emerald green (money, growth, rewards) */
-  --accent: #059669;
-  --accent-strong: #047857;
-  --accent-contrast: #ffffff;
+  /* ─── Brand / Primary ─── */
+  --primary: #4edea3;
+  --primary-container: #10b981;
+  --primary-fixed: #6ffbbe;
+  --primary-fixed-dim: #4edea3;
+  --on-primary: #003824;
 
-  /* Semantic */
-  --border-default: #e2e8f0;
-  --muted: #f1f5f9;
-  --ring-strong: #059669;
+  /* ─── Secondary ─── */
+  --secondary: #d0bcff;
+  --secondary-container: #571bc1;
+  --on-secondary-container: #c4abff;
 
-  --success-bg: #f0fdf4;
-  --success-fg: #16a34a;
-  --warning-bg: #fffbeb;
-  --warning-fg: #d97706;
-  --info-bg: #eff6ff;
-  --info-fg: #2563eb;
-  --danger: #dc2626;
+  /* ─── Tertiary ─── */
+  --tertiary: #c3c0ff;
+  --tertiary-container: #9a98ff;
 
-  /* Charts */
-  --chart-1: #059669;
-  --chart-2: #3b82f6;
-  --chart-3: #f59e0b;
-  --chart-4: #ef4444;
-  --chart-5: #8b5cf6;
+  /* ─── Outline ─── */
+  --outline: #86948a;
+  --outline-variant: #3c4a42;
 
-  /* Gradients */
-  --gradient-page: linear-gradient(to bottom, #f8fafc, #ffffff, #f8fafc);
-  --gradient-header: linear-gradient(to right, #f8fafc, #ffffff, #f8fafc);
-  --gradient-accent: #059669;
-  --gradient-cta: linear-gradient(135deg, #059669 0%, #047857 100%);
+  /* ─── Semantic ─── */
+  --error: #ffb4ab;
+  --error-container: #93000a;
+  --surface-tint: #4edea3;
 
-  /* Radii */
-  --radius: 0.5rem;
+  /* ─── Gradients ─── */
+  --gradient-cta: linear-gradient(135deg, #4edea3 0%, #10b981 100%);
+  --shadow-ambient: 0px 24px 48px -12px rgba(0, 0, 0, 0.4);
+  --shadow-card: 0px 8px 24px -8px rgba(0, 0, 0, 0.3);
 
-  /* Shadows — clean and minimal */
-  --shadow-soft: 0 1px 3px 0 rgba(0, 0, 0, 0.08), 0 1px 2px -1px rgba(0, 0, 0, 0.08);
-  --shadow-strong: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-}
+  /* ─── Border radius ─── */
+  --radius: 1rem;
+  --radius-lg: 2rem;
+  --radius-xl: 3rem;
 
-/* ─── DARK THEME (system preference) ─── */
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* Surfaces — near-black to zinc */
-    --surface: #111113;
-    --surface-muted: #0a0a0b;
-    --surface-soft: #18181b;
-    --surface-strong: #27272a;
-    --surface-subtle: #3f3f46;
+  /* ─── Legacy aliases (used by globals.css @theme inline) ─── */
+  --surface-muted: var(--surface-container-lowest);
+  --surface-soft: var(--surface-container-low);
+  --surface-strong: var(--surface-container-high);
+  --surface-subtle: var(--surface-container-highest);
+  --text-primary: var(--on-surface);
+  --text-secondary: var(--on-surface-variant);
+  --text-inverse: var(--on-primary);
+  --accent: var(--primary);
+  --accent-strong: var(--primary-fixed);
+  --accent-contrast: var(--on-primary);
+  --border-default: rgba(255, 255, 255, 0.05);
+  --muted: var(--surface-container);
+  --ring-strong: var(--primary);
+  --danger: var(--error);
 
-    /* Text — white to zinc */
-    --text-primary: #fafafa;
-    --text-secondary: #a1a1aa;
-    --text-inverse: #0a0a0b;
-
-    /* Accent — brighter emerald on dark bg */
-    --accent: #10b981;
-    --accent-strong: #34d399;
-    --accent-contrast: #ffffff;
-
-    /* Semantic */
-    --border-default: #27272a;
-    --muted: #18181b;
-    --ring-strong: #10b981;
-
-    --success-bg: rgba(16, 185, 129, 0.12);
-    --success-fg: #34d399;
-    --warning-bg: rgba(245, 158, 11, 0.12);
-    --warning-fg: #fbbf24;
-    --info-bg: rgba(59, 130, 246, 0.12);
-    --info-fg: #60a5fa;
-    --danger: #f87171;
-
-    /* Charts */
-    --chart-1: #10b981;
-    --chart-2: #60a5fa;
-    --chart-3: #fbbf24;
-    --chart-4: #f87171;
-    --chart-5: #a78bfa;
-
-    /* Gradients */
-    --gradient-page: linear-gradient(to bottom, #0a0a0b, #111113, #0a0a0b);
-    --gradient-header: linear-gradient(to right, #0a0a0b, #111113, #0a0a0b);
-    --gradient-accent: #10b981;
-    --gradient-cta: linear-gradient(135deg, #10b981 0%, #059669 100%);
-
-    /* Shadows */
-    --shadow-soft: 0 1px 3px 0 rgba(0, 0, 0, 0.4);
-    --shadow-strong: 0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
-  }
-}
-
-/* ─── EXPLICIT .dark CLASS (manual override) ─── */
-.dark {
-  --surface: #111113;
-  --surface-muted: #0a0a0b;
-  --surface-soft: #18181b;
-  --surface-strong: #27272a;
-  --surface-subtle: #3f3f46;
-
-  --text-primary: #fafafa;
-  --text-secondary: #a1a1aa;
-  --text-inverse: #0a0a0b;
-
-  --accent: #10b981;
-  --accent-strong: #34d399;
-  --accent-contrast: #ffffff;
-
-  --border-default: #27272a;
-  --muted: #18181b;
-  --ring-strong: #10b981;
-
-  --success-bg: rgba(16, 185, 129, 0.12);
-  --success-fg: #34d399;
+  --success-bg: rgba(78, 222, 163, 0.12);
+  --success-fg: #4edea3;
   --warning-bg: rgba(245, 158, 11, 0.12);
   --warning-fg: #fbbf24;
-  --info-bg: rgba(59, 130, 246, 0.12);
-  --info-fg: #60a5fa;
-  --danger: #f87171;
+  --info-bg: rgba(192, 188, 255, 0.12);
+  --info-fg: #c3c0ff;
 
-  --chart-1: #10b981;
-  --chart-2: #60a5fa;
+  /* ─── Charts ─── */
+  --chart-1: #4edea3;
+  --chart-2: #d0bcff;
   --chart-3: #fbbf24;
-  --chart-4: #f87171;
-  --chart-5: #a78bfa;
+  --chart-4: #ffb4ab;
+  --chart-5: #9a98ff;
 
-  --gradient-page: linear-gradient(to bottom, #0a0a0b, #111113, #0a0a0b);
-  --gradient-header: linear-gradient(to right, #0a0a0b, #111113, #0a0a0b);
-  --gradient-accent: #10b981;
-  --gradient-cta: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  /* ─── Gradients (legacy aliases) ─── */
+  --gradient-page: linear-gradient(to bottom, #0a0e1a, #0f131f, #0a0e1a);
+  --gradient-header: linear-gradient(to right, #0a0e1a, #0f131f, #0a0e1a);
+  --gradient-accent: #4edea3;
 
-  --shadow-soft: 0 1px 3px 0 rgba(0, 0, 0, 0.4);
-  --shadow-strong: 0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
-}
-
-/* ─── EXPLICIT .light CLASS (force light on dark system) ─── */
-.light {
-  --surface: #ffffff;
-  --surface-muted: #f8fafc;
-  --surface-soft: #f1f5f9;
-  --surface-strong: #e2e8f0;
-  --surface-subtle: #cbd5e1;
-
-  --text-primary: #0f172a;
-  --text-secondary: #64748b;
-  --text-inverse: #ffffff;
-
-  --accent: #059669;
-  --accent-strong: #047857;
-  --accent-contrast: #ffffff;
-
-  --border-default: #e2e8f0;
-  --muted: #f1f5f9;
-  --ring-strong: #059669;
-
-  --success-bg: #f0fdf4;
-  --success-fg: #16a34a;
-  --warning-bg: #fffbeb;
-  --warning-fg: #d97706;
-  --info-bg: #eff6ff;
-  --info-fg: #2563eb;
-  --danger: #dc2626;
-
-  --chart-1: #059669;
-  --chart-2: #3b82f6;
-  --chart-3: #f59e0b;
-  --chart-4: #ef4444;
-  --chart-5: #8b5cf6;
-
-  --gradient-page: linear-gradient(to bottom, #f8fafc, #ffffff, #f8fafc);
-  --gradient-header: linear-gradient(to right, #f8fafc, #ffffff, #f8fafc);
-  --gradient-accent: #059669;
-  --gradient-cta: linear-gradient(135deg, #059669 0%, #047857 100%);
-
-  --shadow-soft: 0 1px 3px 0 rgba(0, 0, 0, 0.08), 0 1px 2px -1px rgba(0, 0, 0, 0.08);
-  --shadow-strong: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  /* ─── Shadows (legacy aliases) ─── */
+  --shadow-soft: var(--shadow-card);
+  --shadow-strong: var(--shadow-ambient);
 }

--- a/app/src/types/database.types.ts
+++ b/app/src/types/database.types.ts
@@ -1157,6 +1157,72 @@ export type Database = {
           },
         ]
       }
+      stripe_customers: {
+        Row: {
+          id: string
+          user_id: string
+          stripe_customer_id: string
+          has_used_trial: boolean
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          stripe_customer_id: string
+          has_used_trial?: boolean
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          stripe_customer_id?: string
+          has_used_trial?: boolean
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      stripe_subscriptions: {
+        Row: {
+          id: string
+          user_id: string
+          stripe_subscription_id: string
+          stripe_price_id: string
+          status: string
+          current_period_start: string | null
+          current_period_end: string | null
+          cancel_at_period_end: boolean
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          stripe_subscription_id: string
+          stripe_price_id: string
+          status: string
+          current_period_start?: string | null
+          current_period_end?: string | null
+          cancel_at_period_end?: boolean
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          stripe_subscription_id?: string
+          stripe_price_id?: string
+          status?: string
+          current_period_start?: string | null
+          current_period_end?: string | null
+          cancel_at_period_end?: boolean
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       cdr_products: {
         Row: {
           id: string


### PR DESCRIPTION
## Summary
- Replaces the old light/dark token system with the **Financial Luminary** dark-only palette (emerald primary `#4edea3`, indigo secondary `#d0bcff`, deep charcoal surfaces)
- Adds glassmorphism utility classes (`.glass`, `.glass-card`, `.glass-panel`, `.arc-glow`, `.premium-glow`, `.tabular`) and Google Fonts (Plus Jakarta Sans + Inter) to globals.css
- Redesigns AppShell with a fixed `w-64` sidebar on desktop, flat 6-item nav, and a 5-item mobile bottom bar — removes nested sub-items, ChevronRight chevrons and the Add Card button
- Fixes pre-existing type errors: adds `stripe_customers`/`stripe_subscriptions` tables to database types, adds optional props to `ProGateProps`, exports `ProBadge` component

## Test plan
- [ ] TypeScript: `pnpm typecheck` passes with zero errors
- [ ] Desktop sidebar visible at ≥768px, `w-64` fixed left, Financial Luminary branding
- [ ] Mobile bottom nav shows 5 items (no Account), active item renders in `#4edea3`
- [ ] No light-mode styles bleed through (all surfaces use dark palette tokens)
- [ ] Glassmorphism classes render correctly on overlays/modals

Closes #160. Closes #161.