### PR TITLE
feat(design): spend tracker arc + profit dashboard

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -251,6 +251,19 @@
   }
 }
 
+/* ─── Glassmorphism utilities ─── */
+.glass-panel {
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+.arc-glow {
+  filter: drop-shadow(0 0 8px rgba(78, 222, 163, 0.4));
+}
+.premium-glow {
+  box-shadow: 0 0 20px rgba(78, 222, 163, 0.15), inset 0 0 10px rgba(78, 222, 163, 0.05);
+}
+
 /* ─── Page view transitions (progressive enhancement) ─── */
 @supports (view-transition-name: none) {
   @view-transition {

--- a/app/src/app/profit/page.tsx
+++ b/app/src/app/profit/page.tsx
@@ -2,9 +2,16 @@
 
 import { useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
-import { TrendingUp, Download, AlertTriangle, CheckCircle } from "lucide-react"
+import { Download, AlertTriangle, CheckCircle, TrendingUp } from "lucide-react"
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
 import { AppShell } from "@/components/layout/AppShell"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ProGate } from "@/components/ui/ProGate"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase/client"
@@ -21,10 +28,18 @@ interface FYRow {
   netValue: number
 }
 
-type Tab = 'all' | 'personal' | 'business'
+type Tab = "all" | "personal" | "business"
 
 function fmtAud(n: number) {
-  return n.toLocaleString("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 })
+  return n.toLocaleString("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  })
+}
+
+function currentFY(): string {
+  return getFinancialYear(new Date().toISOString())
 }
 
 function computeSummary(cards: ProfitCard[]) {
@@ -45,13 +60,67 @@ function computeSummary(cards: ProfitCard[]) {
   }
 }
 
+/** Build monthly area chart data from cards earned this FY */
+function buildChartData(cards: ProfitCard[], fy: string) {
+  const fyCards = cards.filter((c) => c.fy === fy && c.bonusEarnedAt)
+  if (fyCards.length === 0) return []
+
+  // Group by month label
+  const byMonth: Record<string, { bonuses: number; fees: number }> = {}
+  for (const c of fyCards) {
+    const d = new Date(c.bonusEarnedAt)
+    const key = d.toLocaleDateString("en-AU", { month: "short", year: "2-digit" })
+    if (!byMonth[key]) byMonth[key] = { bonuses: 0, fees: 0 }
+    byMonth[key].bonuses += c.bonusAud
+    byMonth[key].fees += c.fee
+  }
+
+  // Sort by date
+  const sorted = Object.entries(byMonth).sort(([a], [b]) => {
+    const parseKey = (k: string) => {
+      const [mon, yr] = k.split(" ")
+      return new Date(`${mon} 20${yr}`)
+    }
+    return parseKey(a).getTime() - parseKey(b).getTime()
+  })
+
+  // Cumulative net
+  let cumNet = 0
+  return sorted.map(([month, { bonuses, fees }]) => {
+    cumNet += bonuses - fees
+    return { month, net: Math.round(cumNet) }
+  })
+}
+
+// Custom Recharts tooltip with glass-panel styling
+function GlassTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean
+  payload?: Array<{ value: number }>
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+  return (
+    <div
+      className="glass-panel rounded-xl px-4 py-3 text-sm"
+      style={{ minWidth: 120 }}
+    >
+      <p className="text-[10px] font-bold uppercase tracking-widest text-[#bbcabf]">{label}</p>
+      <p className="mt-1 font-bold tabular-nums text-[#4edea3]">{fmtAud(payload[0].value)}</p>
+    </div>
+  )
+}
+
 export default function ProfitPage() {
   const router = useRouter()
   const [allCards, setAllCards] = useState<ProfitCard[]>([])
   const [isPro, setIsPro] = useState(false)
   const [isBusiness, setIsBusiness] = useState(false)
   const [loading, setLoading] = useState(true)
-  const [activeTab, setActiveTab] = useState<Tab>('all')
+  const [activeTab, setActiveTab] = useState<Tab>("all")
 
   useEffect(() => {
     async function load() {
@@ -119,13 +188,27 @@ export default function ProfitPage() {
   const hasBusinessCards = useMemo(() => allCards.some((c) => c.is_business), [allCards])
 
   const visibleCards = useMemo(() => {
-    if (activeTab === 'personal') return allCards.filter((c) => !c.is_business)
-    if (activeTab === 'business') return allCards.filter((c) => c.is_business)
+    if (activeTab === "personal") return allCards.filter((c) => !c.is_business)
+    if (activeTab === "business") return allCards.filter((c) => c.is_business)
     return allCards
   }, [allCards, activeTab])
 
   const { totalBonusAud, totalFees, netProfit, fyRows } = useMemo(
     () => computeSummary(visibleCards),
+    [visibleCards],
+  )
+
+  const fy = currentFY()
+  const fyCards = useMemo(() => visibleCards.filter((c) => c.fy === fy), [visibleCards, fy])
+  const fyBonus = fyCards.reduce((s, c) => s + c.bonusAud, 0)
+  const fyFees = fyCards.reduce((s, c) => s + c.fee, 0)
+  const fyNet = fyBonus - fyFees
+
+  const chartData = useMemo(() => buildChartData(visibleCards, fy), [visibleCards, fy])
+
+  // Per-card ROI table sorted by netValue desc
+  const roiRows = useMemo(
+    () => [...visibleCards].sort((a, b) => b.netValue - a.netValue),
     [visibleCards],
   )
 
@@ -139,17 +222,14 @@ export default function ProfitPage() {
         pointsProgram: c.pointsProgram,
       })),
     )
-  }, [allCards, isBusiness])
+  }, [allCards])
 
   if (loading) {
     return (
       <AppShell>
         <div className="space-y-4">
           {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              className="h-24 animate-pulse rounded-xl bg-[var(--surface-subtle)]"
-            />
+            <div key={i} className="h-24 animate-pulse rounded-2xl bg-[#1b1f2c]" />
           ))}
         </div>
       </AppShell>
@@ -160,12 +240,17 @@ export default function ProfitPage() {
 
   return (
     <AppShell>
-      <div className="space-y-5">
-        {/* Page header */}
+      <div className="space-y-6 pb-10">
+        {/* Export buttons row */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-semibold text-[var(--text-primary)]">Net Profit</h1>
-            <p className="mt-0.5 text-sm text-[var(--text-secondary)]">Your churning P&amp;L</p>
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#4edea3]">Track</p>
+            <h1
+              className="mt-1 bg-gradient-to-br from-[#4edea3] to-[#10b981] bg-clip-text text-2xl font-black text-transparent"
+              style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+            >
+              Profit Dashboard
+            </h1>
           </div>
           <div className="flex items-center gap-2">
             {isPro && allCards.length > 0 && (
@@ -173,17 +258,23 @@ export default function ProfitPage() {
                 variant="outline"
                 size="sm"
                 onClick={() => exportProfitCsv(visibleCards)}
+                className="border-white/10 text-[#bbcabf] hover:text-white"
               >
                 <Download className="mr-1.5 h-3.5 w-3.5" />
-                Export CSV
+                CSV
               </Button>
             )}
             {allCards.length > 0 && (
-              <ProGate feature="annual report" isPro={isBusiness} requiredTier="business">
-                <Button variant="outline" size="sm" asChild>
+              <ProGate feature="annual report">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  asChild
+                  className="border-white/10 text-[#bbcabf] hover:text-white"
+                >
                   <a href="/api/business/report" download>
                     <Download className="mr-1.5 h-3.5 w-3.5" />
-                    Annual Report (PDF)
+                    PDF Report
                   </a>
                 </Button>
               </ProGate>
@@ -191,19 +282,19 @@ export default function ProfitPage() {
           </div>
         </div>
 
-        {/* All / Personal / Business tabs — only when business cards exist, Business tier only */}
+        {/* Tab selector — business only */}
         {hasBusinessCards && (
-          <ProGate feature="personal/business P&L split" isPro={isBusiness} requiredTier="business">
-            <div className="flex gap-1 rounded-lg border border-[var(--border-default)] bg-[var(--surface)] p-1">
-              {(['all', 'personal', 'business'] as Tab[]).map((tab) => (
+          <ProGate feature="personal/business P&L split">
+            <div className="flex gap-1 rounded-xl border border-white/10 bg-[#1b1f2c] p-1">
+              {(["all", "personal", "business"] as Tab[]).map((tab) => (
                 <button
                   key={tab}
                   type="button"
                   onClick={() => setActiveTab(tab)}
-                  className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium capitalize transition-colors ${
+                  className={`flex-1 rounded-lg px-3 py-1.5 text-sm font-medium capitalize transition-colors ${
                     activeTab === tab
-                      ? 'bg-[var(--accent)] text-white'
-                      : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+                      ? "bg-[#4edea3] text-[#003824]"
+                      : "text-[#bbcabf] hover:text-white"
                   }`}
                 >
                   {tab}
@@ -214,159 +305,310 @@ export default function ProfitPage() {
         )}
 
         {isEmpty ? (
-          <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-            <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-              <TrendingUp className="mb-3 h-10 w-10 text-[var(--text-secondary)]/40" />
-              <p className="text-sm font-medium text-[var(--text-primary)]">No bonuses confirmed yet</p>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                Mark a card bonus as received on the dashboard to start your P&amp;L
-              </p>
-            </CardContent>
-          </Card>
+          <div className="glass-panel premium-glow flex flex-col items-center justify-center rounded-2xl py-16 text-center">
+            <TrendingUp className="mb-3 h-10 w-10 text-[#bbcabf]/40" />
+            <p className="font-medium text-white">No bonuses confirmed yet</p>
+            <p className="mt-1 text-sm text-[#bbcabf]">
+              Mark a card bonus as received on the dashboard to start your P&amp;L
+            </p>
+          </div>
         ) : (
           <>
-            {/* Headline P&L card — always visible */}
-            <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-              <CardHeader className="pb-2 pt-5">
-                <CardTitle className="text-sm font-medium text-[var(--text-secondary)]">
-                  {activeTab === 'all' ? 'All-time summary' : activeTab === 'personal' ? 'Personal cards summary' : 'Business cards summary'}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+            {/* ── Hero ──────────────────────────────────────────────── */}
+            <div
+              className="relative overflow-hidden rounded-2xl bg-[#1b1f2c] p-8"
+              style={{ boxShadow: "0 0 40px rgba(78,222,163,0.06)" }}
+            >
+              {/* Decorative glow */}
+              <div
+                className="pointer-events-none absolute right-0 top-0 h-64 w-64 rounded-full blur-3xl"
+                style={{ background: "rgba(78,222,163,0.05)", transform: "translate(30%,-30%)" }}
+              />
+              <p className="text-xs font-bold uppercase tracking-[0.3em] text-[#86948a]">
+                {fy} Net Profit
+              </p>
+              <div className="mt-3 flex items-baseline gap-1">
+                <span
+                  className="tabular-nums text-5xl font-extrabold text-[#4edea3]"
+                  style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                >
+                  {fmtAud(fyNet)}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-[#bbcabf]">This financial year</p>
+
+              {/* Stat cards */}
+              <div className="mt-8 grid grid-cols-2 gap-4">
+                <div className="rounded-2xl bg-[#1b1f2c] p-5" style={{ border: "1px solid rgba(78,222,163,0.12)" }}>
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                    Bonuses Earned
+                  </p>
+                  <p
+                    className="mt-2 tabular-nums text-2xl font-bold text-[#4edea3]"
+                    style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                  >
+                    +{fmtAud(fyBonus)}
+                  </p>
+                </div>
+                <div className="rounded-2xl bg-[#1b1f2c] p-5" style={{ border: "1px solid rgba(255,255,255,0.05)" }}>
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                    Fees Paid
+                  </p>
+                  <p
+                    className="mt-2 tabular-nums text-2xl font-bold text-[#bbcabf]"
+                    style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                  >
+                    -{fmtAud(fyFees)}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* ── Area chart ─────────────────────────────────────────── */}
+            {chartData.length > 1 && (
+              <div className="rounded-2xl bg-[#1b1f2c] p-6" style={{ border: "1px solid rgba(255,255,255,0.05)" }}>
+                <p
+                  className="mb-4 text-sm font-bold text-white"
+                  style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                >
+                  Cumulative Profit — {fy}
+                </p>
+                <div className="h-48">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={chartData} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
+                      <defs>
+                        <linearGradient id="profitGradient" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stopColor="#4edea3" stopOpacity={0.2} />
+                          <stop offset="100%" stopColor="#4edea3" stopOpacity={0} />
+                        </linearGradient>
+                      </defs>
+                      <XAxis
+                        dataKey="month"
+                        tick={{ fill: "#86948a", fontSize: 10, fontFamily: "Inter" }}
+                        axisLine={false}
+                        tickLine={false}
+                      />
+                      <YAxis hide />
+                      <Tooltip content={<GlassTooltip />} />
+                      <Area
+                        type="monotone"
+                        dataKey="net"
+                        stroke="#4edea3"
+                        strokeWidth={2}
+                        fill="url(#profitGradient)"
+                        dot={false}
+                        activeDot={{ r: 4, fill: "#4edea3", strokeWidth: 0 }}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            )}
+
+            {/* ── FBT exposure ───────────────────────────────────────── */}
+            {fbtResults.length > 0 && (
+              <ProGate feature="FBT calculator">
+                <div className="space-y-2">
+                  {fbtResults.map((result) => (
+                    <div
+                      key={result.fbtYear}
+                      className={`rounded-xl border p-4 ${
+                        result.thresholdExceeded
+                          ? "border-yellow-500/40 bg-yellow-500/10"
+                          : "border-[#4edea3]/20 bg-[#4edea3]/5"
+                      }`}
+                    >
+                      <div className="flex items-start gap-3">
+                        {result.thresholdExceeded ? (
+                          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-400" />
+                        ) : (
+                          <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-[#4edea3]" />
+                        )}
+                        <div className="space-y-1 text-sm">
+                          {result.thresholdExceeded ? (
+                            <>
+                              <p className="font-semibold text-yellow-300">
+                                FBT Exposure Indicator — {result.fbtYear}
+                              </p>
+                              <p className="text-[#bbcabf]">
+                                You earned {result.totalBusinessPoints.toLocaleString()} business card
+                                points (~{fmtAud(result.totalBusinessAud)}) this FBT year. This exceeds
+                                the 250,000-point indicative threshold.
+                              </p>
+                              <p className="text-[#bbcabf]">
+                                Indicative FBT exposure: ~{fmtAud(result.estimatedFbtLiability)} (47% of
+                                ~{fmtAud(result.estimatedTaxableValue)})
+                              </p>
+                            </>
+                          ) : (
+                            <>
+                              <p className="font-semibold text-[#4edea3]">
+                                Under FBT threshold — {result.fbtYear}
+                              </p>
+                              <p className="text-[#bbcabf]">
+                                {result.totalBusinessPoints.toLocaleString()} business card points
+                                earned — under the 250,000-point indicative threshold.
+                              </p>
+                            </>
+                          )}
+                          <p className="text-xs text-[#bbcabf]/60">{result.disclaimer}</p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </ProGate>
+            )}
+
+            {/* ── Per-card ROI table ─────────────────────────────────── */}
+            <ProGate feature="card breakdown">
+              <div
+                className="rounded-2xl bg-[#1b1f2c] overflow-hidden"
+                style={{ border: "1px solid rgba(255,255,255,0.05)" }}
+              >
+                <div className="px-6 pt-6 pb-3">
+                  <p
+                    className="text-sm font-bold text-white"
+                    style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                  >
+                    Per-Card ROI
+                  </p>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr>
+                        <th className="px-6 py-2.5 text-left text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          Card
+                        </th>
+                        <th className="px-4 py-2.5 text-right text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          Bonus Earned
+                        </th>
+                        <th className="px-4 py-2.5 text-right text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          Annual Fee
+                        </th>
+                        <th className="px-6 py-2.5 text-right text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          Net Value
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {roiRows.map((card) => (
+                        <tr key={card.id} className="hover:bg-white/[0.02] transition-colors">
+                          <td className="px-6 py-3.5 font-medium text-[#dfe2f3]">
+                            {card.bank} {card.name}
+                          </td>
+                          <td className="px-4 py-3.5 text-right tabular-nums text-[#dfe2f3]">
+                            {fmtAud(card.bonusAud)}
+                          </td>
+                          <td className="px-4 py-3.5 text-right tabular-nums text-[#bbcabf]">
+                            {fmtAud(card.fee)}
+                          </td>
+                          <td
+                            className={`px-6 py-3.5 text-right tabular-nums font-bold ${
+                              card.netValue >= 0 ? "text-[#4edea3]" : "text-[#ffb4ab]"
+                            }`}
+                          >
+                            {fmtAud(card.netValue)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </ProGate>
+
+            {/* ── FY breakdown table — Pro only ──────────────────────── */}
+            <ProGate feature="profit breakdown">
+              <div
+                className="rounded-2xl bg-[#1b1f2c] overflow-hidden"
+                style={{ border: "1px solid rgba(255,255,255,0.05)" }}
+              >
+                <div className="px-6 pt-6 pb-3">
+                  <p
+                    className="text-sm font-bold text-white"
+                    style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                  >
+                    By Financial Year
+                  </p>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr>
+                        <th className="px-6 py-2.5 text-left text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          FY
+                        </th>
+                        <th className="px-4 py-2.5 text-right text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          Bonuses
+                        </th>
+                        <th className="px-4 py-2.5 text-right text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          Fees
+                        </th>
+                        <th className="px-6 py-2.5 text-right text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                          Net
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {fyRows.map((row) => (
+                        <tr key={row.fy} className="hover:bg-white/[0.02] transition-colors">
+                          <td className="px-6 py-3.5 font-medium text-[#dfe2f3]">{row.fy}</td>
+                          <td className="px-4 py-3.5 text-right tabular-nums text-[#dfe2f3]">
+                            {fmtAud(row.bonusAud)}
+                          </td>
+                          <td className="px-4 py-3.5 text-right tabular-nums text-[#bbcabf]">
+                            {fmtAud(row.fee)}
+                          </td>
+                          <td
+                            className={`px-6 py-3.5 text-right tabular-nums font-bold ${
+                              row.netValue >= 0 ? "text-[#4edea3]" : "text-[#ffb4ab]"
+                            }`}
+                          >
+                            {fmtAud(row.netValue)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </ProGate>
+
+            {/* Leaderboard */}
+            <Leaderboard isPro={isPro} />
+
+            {/* All-time summary (collapsed detail) */}
+            {activeTab !== "all" && (
+              <div className="rounded-2xl bg-[#1b1f2c] p-6" style={{ border: "1px solid rgba(255,255,255,0.05)" }}>
+                <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-[#86948a]">
+                  All-time Summary
+                </p>
                 <div className="grid grid-cols-3 gap-4">
                   <div>
-                    <p className="text-xs text-[var(--text-secondary)]">Total bonuses</p>
-                    <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                    <p className="text-xs text-[#bbcabf]">Total bonuses</p>
+                    <p className="mt-1 tabular-nums text-lg font-bold text-[#dfe2f3]">
                       {fmtAud(totalBonusAud)}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-[var(--text-secondary)]">Total fees paid</p>
-                    <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                    <p className="text-xs text-[#bbcabf]">Total fees paid</p>
+                    <p className="mt-1 tabular-nums text-lg font-bold text-[#dfe2f3]">
                       {fmtAud(totalFees)}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-[var(--text-secondary)]">Net profit</p>
+                    <p className="text-xs text-[#bbcabf]">Net profit</p>
                     <p
-                      className="mt-1 text-2xl font-bold"
-                      style={{ color: netProfit >= 0 ? "var(--accent)" : "#ef4444" }}
+                      className={`mt-1 tabular-nums text-2xl font-bold ${netProfit >= 0 ? "text-[#4edea3]" : "text-[#ffb4ab]"}`}
                     >
                       {fmtAud(netProfit)}
                     </p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-
-            {/* FBT exposure section — Business tier only */}
-            {fbtResults.length > 0 && (
-              <ProGate feature="FBT calculator" isPro={isBusiness} requiredTier="business">
-            <div className="space-y-2">
-                {fbtResults.map((result) => (
-                  <div
-                    key={result.fbtYear}
-                    className={`rounded-xl border p-4 ${
-                      result.thresholdExceeded
-                        ? 'border-yellow-500/40 bg-yellow-500/10'
-                        : 'border-green-500/40 bg-green-500/10'
-                    }`}
-                  >
-                    <div className="flex items-start gap-3">
-                      {result.thresholdExceeded ? (
-                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-400" />
-                      ) : (
-                        <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-green-400" />
-                      )}
-                      <div className="space-y-1 text-sm">
-                        {result.thresholdExceeded ? (
-                          <>
-                            <p className="font-semibold text-yellow-300">
-                              FBT Exposure Indicator — {result.fbtYear}
-                            </p>
-                            <p className="text-[var(--text-secondary)]">
-                              You earned {result.totalBusinessPoints.toLocaleString()} business card points (~{fmtAud(result.totalBusinessAud)}) this FBT year.
-                              This exceeds the 250,000-point indicative threshold.
-                            </p>
-                            <p className="text-[var(--text-secondary)]">
-                              Indicative FBT exposure: ~{fmtAud(result.estimatedFbtLiability)} (47% of ~{fmtAud(result.estimatedTaxableValue)})
-                            </p>
-                          </>
-                        ) : (
-                          <>
-                            <p className="font-semibold text-green-300">
-                              Under FBT threshold — {result.fbtYear}
-                            </p>
-                            <p className="text-[var(--text-secondary)]">
-                              {result.totalBusinessPoints.toLocaleString()} business card points earned — under the 250,000-point indicative threshold.
-                            </p>
-                          </>
-                        )}
-                        <p className="text-xs text-[var(--text-secondary)]/70">{result.disclaimer}</p>
-                      </div>
-                    </div>
-                  </div>
-                ))}
               </div>
-              </ProGate>
             )}
-
-            {/* Financial year breakdown — Pro only */}
-            <ProGate feature="profit breakdown" isPro={isPro} previewRows={3}>
-              <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-                <CardHeader className="pb-2 pt-5">
-                  <CardTitle className="text-sm font-medium text-[var(--text-secondary)]">
-                    By financial year
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="p-0">
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="border-b border-[var(--border-default)] text-xs text-[var(--text-secondary)]">
-                          <th className="px-4 py-2.5 text-left font-medium">FY</th>
-                          <th className="px-4 py-2.5 text-right font-medium">Bonuses</th>
-                          <th className="px-4 py-2.5 text-right font-medium">Fees</th>
-                          <th className="px-4 py-2.5 text-right font-medium">Net</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {fyRows.map((row) => (
-                          <tr
-                            key={row.fy}
-                            className="border-b border-[var(--border-default)] last:border-0"
-                          >
-                            <td className="px-4 py-3 font-medium text-[var(--text-primary)]">
-                              {row.fy}
-                            </td>
-                            <td className="px-4 py-3 text-right text-[var(--text-primary)]">
-                              {fmtAud(row.bonusAud)}
-                            </td>
-                            <td className="px-4 py-3 text-right text-[var(--text-secondary)]">
-                              {fmtAud(row.fee)}
-                            </td>
-                            <td
-                              className="px-4 py-3 text-right font-semibold"
-                              style={{ color: row.netValue >= 0 ? "var(--accent)" : "#ef4444" }}
-                            >
-                              {fmtAud(row.netValue)}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </CardContent>
-              </Card>
-            </ProGate>
-
-            {/* Card breakdown — Pro only */}
-            <ProGate feature="card breakdown" isPro={isPro} previewRows={3}>
-              <CardBreakdown cards={visibleCards} />
-            </ProGate>
-
-            {/* Leaderboard */}
-            <Leaderboard isPro={isPro} />
           </>
         )}
       </div>

--- a/app/src/app/spending/page.tsx
+++ b/app/src/app/spending/page.tsx
@@ -3,13 +3,9 @@
 import { useEffect, useState } from "react"
 import { supabase } from "@/lib/supabase/client"
 import { AppShell } from "@/components/layout/AppShell"
-import { Card, CardContent } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Badge } from "@/components/ui/badge"
-import { AlertCircle, CheckCircle, Clock, TrendingUp, Plus } from "lucide-react"
 import {
   Dialog,
   DialogContent,
@@ -51,12 +47,143 @@ interface SpendingTransaction {
   category: string
 }
 
+// ─── SVG Arc constants ───────────────────────────────────────────────────────
+const RADIUS = 80
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+const ARC_LENGTH = CIRCUMFERENCE * 0.667 // 240 degrees
+
+function SpendArc({ spent, target }: { spent: number; target: number }) {
+  const pct = target > 0 ? Math.min(spent / target, 1) : 0
+  const filledLength = ARC_LENGTH * pct
+  const viewBoxSize = (RADIUS + 14) * 2
+  const center = RADIUS + 14
+  // Start arc from bottom-left (-210deg) spanning 240 degrees
+  const rotation = -210
+
+  return (
+    <div
+      className="progress-arc-container flex items-center justify-center"
+      style={{ position: "relative" }}
+    >
+      <style>{`
+        .progress-arc-container { transition: transform 300ms ease-out; }
+        .progress-arc-container:hover { transform: scale(1.02); }
+        .progress-arc-container:hover .progress-arc-path {
+          stroke-width: 12 !important;
+          filter: drop-shadow(0 0 12px rgba(78,222,163,0.6));
+        }
+        .progress-arc-container:hover .progress-center-amount {
+          text-shadow: 0 0 15px rgba(255,255,255,0.2);
+        }
+      `}</style>
+      <svg
+        width={viewBoxSize}
+        height={viewBoxSize}
+        viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`}
+        style={{ overflow: "visible" }}
+      >
+        {/* Track */}
+        <circle
+          cx={center}
+          cy={center}
+          r={RADIUS}
+          fill="none"
+          stroke="rgba(255,255,255,0.1)"
+          strokeWidth={10}
+          strokeDasharray={`${ARC_LENGTH} ${CIRCUMFERENCE - ARC_LENGTH}`}
+          strokeLinecap="round"
+          transform={`rotate(${rotation} ${center} ${center})`}
+        />
+        {/* Fill */}
+        <circle
+          className="progress-arc-path arc-glow"
+          cx={center}
+          cy={center}
+          r={RADIUS}
+          fill="none"
+          stroke="#4edea3"
+          strokeWidth={10}
+          strokeDasharray={`${filledLength} ${CIRCUMFERENCE - filledLength}`}
+          strokeLinecap="round"
+          transform={`rotate(${rotation} ${center} ${center})`}
+          style={{
+            transition: "stroke-dasharray 600ms ease-out, stroke-width 300ms ease-out, filter 300ms ease-out",
+          }}
+        />
+        {/* Center text */}
+        <foreignObject x={center - 72} y={center - 38} width={144} height={76}>
+          <div
+            className="flex flex-col items-center justify-center"
+            style={{ height: "100%", textAlign: "center" }}
+          >
+            <span
+              className="progress-center-amount tabular-nums font-bold text-white"
+              style={{
+                fontFamily: "'Plus Jakarta Sans', sans-serif",
+                fontSize: "1.875rem",
+                lineHeight: 1.1,
+                transition: "text-shadow 300ms ease-out",
+              }}
+            >
+              {formatCurrencyCompact(spent)}
+            </span>
+            <span
+              style={{
+                fontSize: "0.7rem",
+                color: "rgba(255,255,255,0.4)",
+                fontFamily: "Inter, sans-serif",
+                marginTop: 3,
+              }}
+            >
+              of {formatCurrencyCompact(target)}
+            </span>
+          </div>
+        </foreignObject>
+      </svg>
+    </div>
+  )
+}
+
+function formatCurrencyCompact(amount: number): string {
+  if (amount >= 1000) return `$${(amount / 1000).toFixed(1)}k`
+  return `$${Math.round(amount)}`
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD" }).format(amount)
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  })
+}
+
+function getPaceStatus(card: UserCard): { label: string; color: string } {
+  if (!card.spend_deadline || !card.spend_target) return { label: "On Track", color: "text-[#4edea3]" }
+
+  const remaining = card.spend_target - card.current_spend
+  if (remaining <= 0) return { label: "Bonus Earned", color: "text-[#4edea3]" }
+
+  const daysLeft = Math.ceil(
+    (new Date(card.spend_deadline).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
+  )
+  if (daysLeft <= 0) return { label: "Will Miss Bonus", color: "text-[#ffb4ab]" }
+
+  const dailyNeeded = remaining / daysLeft
+  if (dailyNeeded > 100) return { label: "Will Miss Bonus", color: "text-[#ffb4ab]" }
+  if (dailyNeeded > 50) return { label: "Behind Pace", color: "text-amber-400" }
+  return { label: "On Track", color: "text-[#4edea3]" }
+}
+
 export default function SpendingTrackerPage() {
   const [userCards, setUserCards] = useState<UserCard[]>([])
   const [transactions, setTransactions] = useState<Record<string, SpendingTransaction[]>>({})
   const [loading, setLoading] = useState(true)
-  const [selectedCard, setSelectedCard] = useState<UserCard | null>(null)
-  const [isAddingTransaction, setIsAddingTransaction] = useState(false)
+  const [selectedCardId, setSelectedCardId] = useState<string | null>(null)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [newTransaction, setNewTransaction] = useState({
     amount: "",
     description: "",
@@ -65,7 +192,7 @@ export default function SpendingTrackerPage() {
   })
 
   useEffect(() => {
-    loadUserCards()
+    void loadUserCards()
   }, [])
 
   const loadUserCards = async () => {
@@ -88,13 +215,11 @@ export default function SpendingTrackerPage() {
       const enrichedCards = (cards || []).map((card: any) => {
         const spendTarget = card.card?.bonus_spend_requirement || 0
         const windowMonths = card.card?.bonus_spend_window_months || 3
-
         let deadline = null
         if (card.activated_date && spendTarget > 0) {
-          const activatedDate = new Date(card.activated_date)
-          deadline = new Date(activatedDate.setMonth(activatedDate.getMonth() + windowMonths))
+          const d = new Date(card.activated_date)
+          deadline = new Date(d.setMonth(d.getMonth() + windowMonths))
         }
-
         return {
           ...card,
           current_spend: card.current_spend || 0,
@@ -104,334 +229,301 @@ export default function SpendingTrackerPage() {
       })
 
       setUserCards(enrichedCards)
+      if (enrichedCards.length > 0) {
+        setSelectedCardId(enrichedCards[0].id)
+      }
 
-      const cardIds = enrichedCards.map((c) => c.id)
-      await loadTransactions(cardIds)
-    } catch (error) {
-      console.error("Error loading cards:", error)
+      const transactionMap: Record<string, SpendingTransaction[]> = {}
+      for (const c of enrichedCards) transactionMap[c.id] = []
+      setTransactions(transactionMap)
+    } catch (err) {
+      console.error("Error loading cards:", err)
     } finally {
       setLoading(false)
     }
   }
 
-  const loadTransactions = async (cardIds: string[]) => {
-    const transactionMap: Record<string, SpendingTransaction[]> = {}
-    cardIds.forEach((id) => {
-      transactionMap[id] = []
-    })
-    setTransactions(transactionMap)
-  }
-
   const handleAddTransaction = async () => {
-    if (!selectedCard || !newTransaction.amount) return
+    const activeCard = userCards.find((c) => c.id === selectedCardId)
+    if (!activeCard || !newTransaction.amount) return
 
     try {
-      const newSpend = (selectedCard.current_spend || 0) + parseFloat(newTransaction.amount)
-
+      const newSpend = activeCard.current_spend + parseFloat(newTransaction.amount)
       const { error } = await supabase
         .from("user_cards")
         .update({ current_spend: newSpend })
-        .eq("id", selectedCard.id)
-
+        .eq("id", activeCard.id)
       if (error) throw error
 
-      setUserCards((cards) =>
-        cards.map((c: UserCard) =>
-          c.id === selectedCard.id ? { ...c, current_spend: newSpend } : c,
-        ),
+      setUserCards((prev) =>
+        prev.map((c) => (c.id === activeCard.id ? { ...c, current_spend: newSpend } : c)),
       )
-
       setNewTransaction({
         amount: "",
         description: "",
         date: new Date().toISOString().split("T")[0],
         category: "general",
       })
-      setIsAddingTransaction(false)
-      setSelectedCard(null)
-    } catch (error) {
-      console.error("Error adding transaction:", error)
+      setIsDialogOpen(false)
+    } catch (err) {
+      console.error("Error adding transaction:", err)
     }
   }
-
-  const getSpendingStatus = (card: UserCard) => {
-    if (!card.spend_target) return { status: "no_target", color: "gray" }
-
-    const progress = (card.current_spend / card.spend_target) * 100
-    const daysLeft = card.spend_deadline
-      ? Math.ceil(
-          (new Date(card.spend_deadline).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
-        )
-      : null
-
-    if (progress >= 100) return { status: "completed", icon: CheckCircle }
-    if (daysLeft !== null && daysLeft < 14) return { status: "urgent", icon: AlertCircle }
-    if (daysLeft !== null && daysLeft < 30) return { status: "warning", icon: Clock }
-    return { status: "on_track", icon: TrendingUp }
-  }
-
-  const formatCurrency = (amount: number) =>
-    new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD" }).format(amount)
-
-  const formatDate = (date: string) =>
-    new Date(date).toLocaleDateString("en-AU", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-    })
 
   if (loading) {
     return (
       <AppShell>
         <div className="space-y-5">
-          <div className="h-14 animate-pulse rounded-xl bg-[var(--surface)]" />
-          <div className="grid grid-cols-3 gap-4">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="h-20 animate-pulse rounded-xl bg-[var(--surface)]" />
-            ))}
-          </div>
+          <div className="h-14 animate-pulse rounded-xl bg-[#1b1f2c]" />
+          <div className="h-64 animate-pulse rounded-2xl bg-[#1b1f2c]" />
           {[1, 2].map((i) => (
-            <div key={i} className="h-32 animate-pulse rounded-xl bg-[var(--surface)]" />
+            <div key={i} className="h-20 animate-pulse rounded-xl bg-[#1b1f2c]" />
           ))}
         </div>
       </AppShell>
     )
   }
 
-  const cardsNeedingSpend = userCards.filter(
-    (c) => c.spend_target > 0 && c.current_spend < c.spend_target,
-  ).length
-  const totalTarget = userCards.reduce((sum, c) => sum + (c.spend_target || 0), 0)
+  const activeCard = userCards.find((c) => c.id === selectedCardId) ?? userCards[0] ?? null
+  const pace = activeCard ? getPaceStatus(activeCard) : null
 
   return (
     <AppShell>
-      <div className="space-y-5">
+      <div className="space-y-6 pb-10">
         {/* Page header */}
         <div>
-          <p className="text-xs font-medium uppercase tracking-widest text-[var(--accent)]">
-            Spending
-          </p>
-          <h1 className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-            Spend tracker
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#4edea3]">Spending</p>
+          <h1
+            className="mt-1 bg-gradient-to-br from-[#4edea3] to-[#10b981] bg-clip-text text-2xl font-black text-transparent"
+            style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+          >
+            Spend Tracker
           </h1>
-          <p className="mt-1 text-sm text-[var(--text-secondary)]">
-            Track progress toward minimum spend requirements
-          </p>
         </div>
 
-        {/* Summary stats */}
-        <div className="grid grid-cols-3 gap-3">
-          <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-            <CardContent className="px-4 py-3">
-              <p className="text-xs text-[var(--text-secondary)]">Active cards</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                {userCards.length}
-              </p>
-            </CardContent>
-          </Card>
-          <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-            <CardContent className="px-4 py-3">
-              <p className="text-xs text-[var(--text-secondary)]">Needs spend</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                {cardsNeedingSpend}
-              </p>
-            </CardContent>
-          </Card>
-          <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-            <CardContent className="px-4 py-3">
-              <p className="text-xs text-[var(--text-secondary)]">Total target</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                {formatCurrency(totalTarget)}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Card spending progress */}
         {userCards.length === 0 ? (
-          <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-            <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
-              <p className="font-medium text-[var(--text-primary)]">No active cards</p>
-              <p className="text-sm text-[var(--text-secondary)]">
-                Add cards with spending requirements to track your progress.
-              </p>
-              <Button
-                size="sm"
-                className="rounded-full"
-                style={{ background: "var(--gradient-cta)" }}
-                onClick={() => (window.location.href = "/cards")}
-              >
-                Add cards
-              </Button>
-            </CardContent>
-          </Card>
+          <div className="glass-panel premium-glow flex flex-col items-center gap-4 rounded-2xl px-8 py-16 text-center">
+            <p
+              className="font-semibold text-white"
+              style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+            >
+              No active cards
+            </p>
+            <p className="text-sm text-[#bbcabf]">
+              Add cards with spending requirements to track your progress.
+            </p>
+            <Button
+              className="rounded-full font-bold text-[#003824]"
+              style={{ background: "var(--gradient-cta)" }}
+              onClick={() => (window.location.href = "/cards")}
+            >
+              Add cards
+            </Button>
+          </div>
         ) : (
-          <div className="space-y-4">
-            {userCards.map((card) => {
-              const status = getSpendingStatus(card)
-              const progress = card.spend_target ? (card.current_spend / card.spend_target) * 100 : 0
-              const StatusIcon = status.icon || TrendingUp
-
-              const badgeStyle =
-                status.status === "completed"
-                  ? { backgroundColor: "var(--success-bg)", color: "var(--success-fg)" }
-                  : status.status === "urgent"
-                    ? { backgroundColor: "var(--danger)", color: "white" }
-                    : status.status === "warning"
-                      ? { backgroundColor: "var(--warning-bg)", color: "var(--warning-fg)" }
-                      : { backgroundColor: "var(--info-bg)", color: "var(--info-fg)" }
-
-              return (
-                <Card
-                  key={card.id}
-                  className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm"
-                  data-spending-card={card.id}
+          <>
+            {/* Card selector */}
+            {userCards.length > 1 && (
+              <div>
+                <Label className="mb-1.5 block text-xs font-bold uppercase tracking-widest text-[#bbcabf]">
+                  Tracking card
+                </Label>
+                <select
+                  value={selectedCardId ?? ""}
+                  onChange={(e) => setSelectedCardId(e.target.value)}
+                  className="w-full rounded-xl border border-white/10 bg-[#1b1f2c] px-4 py-2.5 text-sm text-white focus:outline-none focus:ring-1 focus:ring-[#4edea3]/40"
                 >
-                  <CardContent className="p-5">
-                    <div className="space-y-4">
-                      {/* Card header */}
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <h3 className="font-semibold text-[var(--text-primary)]">
-                            {card.card.bank} — {card.card.name}
-                          </h3>
-                          <div className="mt-1.5 flex flex-wrap gap-2">
-                            <Badge style={badgeStyle}>
-                              <StatusIcon className="mr-1 h-3 w-3" />
-                              {status.status === "completed"
-                                ? "Target met"
-                                : status.status === "urgent"
-                                  ? "Urgent"
-                                  : status.status === "warning"
-                                    ? "Deadline soon"
-                                    : "On track"}
-                            </Badge>
-                            {card.spend_deadline && (
-                              <Badge
-                                variant="outline"
-                                className="border-[var(--border-default)] text-[var(--text-secondary)]"
-                              >
-                                Due {formatDate(card.spend_deadline)}
-                              </Badge>
-                            )}
-                          </div>
-                        </div>
-                        <Dialog
-                          open={isAddingTransaction && selectedCard?.id === card.id}
-                          onOpenChange={(open) => {
-                            setIsAddingTransaction(open)
-                            if (open) setSelectedCard(card)
-                          }}
-                        >
-                          <DialogTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              className="flex-shrink-0 rounded-full"
-                            >
-                              <Plus className="mr-1.5 h-3.5 w-3.5" />
-                              Add spend
-                            </Button>
-                          </DialogTrigger>
-                          <DialogContent>
-                            <DialogHeader>
-                              <DialogTitle>Record transaction</DialogTitle>
-                              <DialogDescription>
-                                Record a purchase made with {card.card.name}
-                              </DialogDescription>
-                            </DialogHeader>
-                            <div className="space-y-4">
-                              <div>
-                                <Label htmlFor="amount">Amount (AUD)</Label>
-                                <Input
-                                  id="amount"
-                                  type="number"
-                                  step="0.01"
-                                  placeholder="100.00"
-                                  value={newTransaction.amount}
-                                  onChange={(e) =>
-                                    setNewTransaction({ ...newTransaction, amount: e.target.value })
-                                  }
-                                />
-                              </div>
-                              <div>
-                                <Label htmlFor="description">Description</Label>
-                                <Input
-                                  id="description"
-                                  placeholder="e.g., Groceries at Woolworths"
-                                  value={newTransaction.description}
-                                  onChange={(e) =>
-                                    setNewTransaction({
-                                      ...newTransaction,
-                                      description: e.target.value,
-                                    })
-                                  }
-                                />
-                              </div>
-                              <div>
-                                <Label htmlFor="date">Date</Label>
-                                <Input
-                                  id="date"
-                                  type="date"
-                                  value={newTransaction.date}
-                                  onChange={(e) =>
-                                    setNewTransaction({ ...newTransaction, date: e.target.value })
-                                  }
-                                />
-                              </div>
-                              <Button onClick={handleAddTransaction} className="w-full">
-                                Save transaction
-                              </Button>
-                            </div>
-                          </DialogContent>
-                        </Dialog>
-                      </div>
+                  {userCards.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.card.bank} — {c.card.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
-                      {/* Progress */}
-                      {card.spend_target > 0 && (
-                        <div className="space-y-1.5">
-                          <div className="flex items-center justify-between text-sm">
-                            <span className="font-medium text-[var(--text-primary)]">
-                              {formatCurrency(card.current_spend)}
-                            </span>
-                            <span className="text-[var(--text-secondary)]">
-                              of {formatCurrency(card.spend_target)}
-                            </span>
-                          </div>
-                          <Progress value={Math.min(progress, 100)} className="h-2" />
-                          <p className="text-xs text-[var(--text-secondary)]">
-                            {progress >= 100
-                              ? "Spending requirement met — bonus points incoming"
-                              : `${formatCurrency(card.spend_target - card.current_spend)} remaining to earn ${card.card.welcome_bonus_points?.toLocaleString() || "bonus"} points`}
+            {activeCard && pace && (
+              <>
+                {/* Arc + stats */}
+                <div className="flex flex-col gap-5 md:flex-row md:items-center">
+                  {/* Arc — 60% width */}
+                  <div className="flex flex-[3] items-center justify-center py-4">
+                    <SpendArc spent={activeCard.current_spend} target={activeCard.spend_target} />
+                  </div>
+
+                  {/* Stats panel — 40% width */}
+                  <div className="glass-panel premium-glow flex flex-[2] flex-col gap-5 rounded-2xl p-6">
+                    {activeCard.spend_deadline && (
+                      <div>
+                        <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[#bbcabf]">
+                          Days Remaining
+                        </p>
+                        <p
+                          className="mt-0.5 text-5xl font-black tabular-nums text-white"
+                          style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                        >
+                          {Math.max(
+                            0,
+                            Math.ceil(
+                              (new Date(activeCard.spend_deadline).getTime() - Date.now()) /
+                                86400000,
+                            ),
+                          )}
+                        </p>
+                      </div>
+                    )}
+
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[#bbcabf]">
+                        Pace
+                      </p>
+                      <p
+                        className={`mt-0.5 text-lg font-bold ${pace.color}`}
+                        style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                      >
+                        {pace.label}
+                      </p>
+                    </div>
+
+                    {activeCard.spend_deadline &&
+                      activeCard.spend_target > activeCard.current_spend && (
+                        <div>
+                          <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[#bbcabf]">
+                            Daily Target
+                          </p>
+                          <p className="mt-0.5 text-lg font-bold tabular-nums text-white">
+                            {(() => {
+                              const daysLeft = Math.ceil(
+                                (new Date(activeCard.spend_deadline).getTime() - Date.now()) /
+                                  86400000,
+                              )
+                              if (daysLeft <= 0) return "—"
+                              return (
+                                formatCurrency(
+                                  (activeCard.spend_target - activeCard.current_spend) / daysLeft,
+                                ) + "/day"
+                              )
+                            })()}
                           </p>
                         </div>
                       )}
 
-                      {/* Recent transactions */}
-                      {transactions[card.id]?.length > 0 && (
-                        <div className="border-t border-[var(--border-default)] pt-3">
-                          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                            Recent transactions
-                          </h4>
-                          <div className="space-y-1">
-                            {transactions[card.id].slice(0, 3).map((txn) => (
-                              <div
-                                key={txn.id}
-                                className="flex justify-between text-sm text-[var(--text-secondary)]"
-                              >
-                                <span>{txn.description}</span>
-                                <span>{formatCurrency(txn.amount)}</span>
-                              </div>
-                            ))}
-                          </div>
+                    {!!activeCard.card.welcome_bonus_points && (
+                      <div>
+                        <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[#bbcabf]">
+                          Earn on Completion
+                        </p>
+                        <p
+                          className="mt-0.5 text-lg font-bold tabular-nums text-[#c3c0ff]"
+                          style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                        >
+                          {activeCard.card.welcome_bonus_points.toLocaleString()} pts
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Recent transactions */}
+                {(transactions[activeCard.id]?.length ?? 0) > 0 && (
+                  <div>
+                    <p className="mb-3 text-[10px] font-bold uppercase tracking-[0.2em] text-[#bbcabf]">
+                      Recent Transactions
+                    </p>
+                    <div className="space-y-2">
+                      {transactions[activeCard.id].slice(0, 5).map((txn) => (
+                        <div
+                          key={txn.id}
+                          className="flex items-center justify-between py-2 text-sm"
+                        >
+                          <span className="text-[#dfe2f3]">{txn.description}</span>
+                          <span className="tabular-nums font-medium text-white">
+                            {formatCurrency(txn.amount)}
+                          </span>
                         </div>
-                      )}
+                      ))}
                     </div>
-                  </CardContent>
-                </Card>
-              )
-            })}
-          </div>
+                  </div>
+                )}
+
+                {/* CTA */}
+                <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+                  <DialogTrigger asChild>
+                    <Button
+                      className="w-full rounded-full py-6 text-base font-bold text-[#003824]"
+                      style={{ background: "var(--gradient-cta)" }}
+                    >
+                      + Add Transaction
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent className="border border-white/10 bg-[#1b1f2c]">
+                    <DialogHeader>
+                      <DialogTitle className="text-white">Record Transaction</DialogTitle>
+                      <DialogDescription className="text-[#bbcabf]">
+                        Record a purchase made with {activeCard.card.name}
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-4">
+                      <div>
+                        <Label htmlFor="amount" className="text-[#bbcabf]">
+                          Amount (AUD)
+                        </Label>
+                        <Input
+                          id="amount"
+                          type="number"
+                          step="0.01"
+                          placeholder="100.00"
+                          value={newTransaction.amount}
+                          onChange={(e) =>
+                            setNewTransaction({ ...newTransaction, amount: e.target.value })
+                          }
+                          className="border-white/10 bg-[#262a37] text-white"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="description" className="text-[#bbcabf]">
+                          Description
+                        </Label>
+                        <Input
+                          id="description"
+                          placeholder="e.g., Groceries at Woolworths"
+                          value={newTransaction.description}
+                          onChange={(e) =>
+                            setNewTransaction({
+                              ...newTransaction,
+                              description: e.target.value,
+                            })
+                          }
+                          className="border-white/10 bg-[#262a37] text-white"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="txn-date" className="text-[#bbcabf]">
+                          Date
+                        </Label>
+                        <Input
+                          id="txn-date"
+                          type="date"
+                          value={newTransaction.date}
+                          onChange={(e) =>
+                            setNewTransaction({ ...newTransaction, date: e.target.value })
+                          }
+                          className="border-white/10 bg-[#262a37] text-white"
+                        />
+                      </div>
+                      <Button
+                        onClick={handleAddTransaction}
+                        className="w-full rounded-full font-bold text-[#003824]"
+                        style={{ background: "var(--gradient-cta)" }}
+                      >
+                        Save Transaction
+                      </Button>
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              </>
+            )}
+          </>
         )}
       </div>
     </AppShell>

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -64,6 +64,7 @@ const navItems: NavItem[] = [
     icon: Wallet,
     children: [
       { href: "/spending", label: "Tracker", icon: Wallet },
+      { href: "/profit", label: "Profit Dashboard", icon: TrendingUp },
       { href: "/statements", label: "Import Statements", icon: Upload },
     ],
   },


### PR DESCRIPTION
## Summary

- SVG donut arc for spend progress (240° sweep, animated fill, hover glow, scale interaction)
- Glassmorphism stats panel: days remaining, pace indicator (On Track / Behind Pace / Will Miss Bonus), daily target, points on completion
- Profit dashboard: FY hero metric, dual stat cards, recharts AreaChart with emerald gradient, per-card ROI table (sorted net desc, emerald/error colouring)
- `globals.css`: `.glass-panel`, `.arc-glow`, `.premium-glow` utility classes
- AppShell: Profit Dashboard added as child nav under Spending

## Test plan

- [ ] Open `/spending` — arc renders, fills on load, hover scales + glows
- [ ] Multiple cards → card selector dropdown appears
- [ ] `+ Add Transaction` dialog opens, updates spend on save
- [ ] Open `/profit` — hero shows current FY net, stat cards show bonuses/fees
- [ ] Area chart renders when >1 data point exists
- [ ] ROI table sorted by net desc; positive = emerald, negative = red
- [ ] Spending nav item expands to show "Profit Dashboard" child link

Closes #164. Closes #165.