### PR TITLE
fix(ci): fix Vercel cron + Financial Luminary theme tokens + dark error pages

### DIFF
--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -11,7 +11,6 @@ export default function Error({
   reset: () => void
 }) {
   useEffect(() => {
-    // Capture error in PostHog
     if (posthog.__loaded) {
       posthog.captureException(error)
     }
@@ -19,22 +18,23 @@ export default function Error({
   }, [error])
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
-      <div className="max-w-md w-full bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
-        <h2 className="text-2xl font-bold text-red-600 dark:text-red-400 mb-4">
+    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: "#0f131f" }}>
+      <div className="max-w-md w-full rounded-2xl border border-white/5 p-6" style={{ background: "#1b1f2c" }}>
+        <h2 className="text-2xl font-bold mb-4" style={{ color: "#ffb4ab" }}>
           Something went wrong!
         </h2>
-        <p className="text-gray-600 dark:text-gray-300 mb-6">
+        <p className="mb-6" style={{ color: "#bbcabf" }}>
           We&apos;ve been notified and will look into it. Please try again.
         </p>
         {process.env.NODE_ENV === "development" && (
-          <pre className="text-sm bg-gray-100 dark:bg-gray-900 p-4 rounded mb-4 overflow-auto">
+          <pre className="text-sm p-4 rounded-lg mb-4 overflow-auto font-mono text-xs" style={{ background: "#0a0e1a", color: "#bbcabf" }}>
             {error.message}
           </pre>
         )}
         <button
           onClick={reset}
-          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
+          className="w-full rounded-full py-2 px-4 font-medium text-[#003824] transition-opacity hover:opacity-90"
+          style={{ background: "linear-gradient(135deg, #4edea3 0%, #10b981 100%)" }}
         >
           Try again
         </button>

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -10,24 +10,24 @@ export default function GlobalError({
   reset: () => void
 }) {
   useEffect(() => {
-    // Log to console in development
     console.error("Global error:", error)
   }, [error])
 
   return (
     <html>
-      <body>
-        <div className="min-h-screen flex items-center justify-center p-4 bg-gray-50 dark:bg-gray-900">
-          <div className="max-w-md w-full bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
-            <h2 className="text-2xl font-bold text-red-600 dark:text-red-400 mb-4">
+      <body style={{ background: "#0f131f", margin: 0 }}>
+        <div className="min-h-screen flex items-center justify-center p-4">
+          <div className="max-w-md w-full rounded-2xl border border-white/5 p-6" style={{ background: "#1b1f2c" }}>
+            <h2 className="text-2xl font-bold mb-4" style={{ color: "#ffb4ab" }}>
               Critical Error
             </h2>
-            <p className="text-gray-600 dark:text-gray-300 mb-6">
+            <p className="mb-6" style={{ color: "#bbcabf" }}>
               Something went critically wrong. Please refresh the page.
             </p>
             <button
               onClick={reset}
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
+              className="w-full rounded-full py-2 px-4 font-medium text-[#003824] transition-opacity hover:opacity-90"
+              style={{ background: "linear-gradient(135deg, #4edea3 0%, #10b981 100%)" }}
             >
               Try again
             </button>

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -46,6 +46,31 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+
+  /* ─── Financial Luminary design system tokens → Tailwind utilities ─── */
+  --color-surface: var(--surface);
+  --color-surface-dim: var(--surface-dim);
+  --color-surface-container-lowest: var(--surface-container-lowest);
+  --color-surface-container-low: var(--surface-container-low);
+  --color-surface-container: var(--surface-container);
+  --color-surface-container-high: var(--surface-container-high);
+  --color-surface-container-highest: var(--surface-container-highest);
+  --color-surface-bright: var(--surface-bright);
+  --color-on-surface: var(--on-surface);
+  --color-on-surface-variant: var(--on-surface-variant);
+  --color-on-background: var(--on-background);
+  --color-on-primary: var(--on-primary);
+  --color-primary-container: var(--primary-container);
+  --color-primary-fixed: var(--primary-fixed);
+  --color-primary-fixed-dim: var(--primary-fixed-dim);
+  --color-secondary-container: var(--secondary-container);
+  --color-on-secondary-container: var(--on-secondary-container);
+  --color-tertiary: var(--tertiary);
+  --color-tertiary-container: var(--tertiary-container);
+  --color-outline: var(--outline);
+  --color-outline-variant: var(--outline-variant);
+  --color-error-container: var(--error-container);
+  --color-surface-tint: var(--surface-tint);
 }
 
 :root {

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -11,7 +11,7 @@
     { "path": "/api/cron/deals-sync",      "schedule": "0 6 * * *"  },
     { "path": "/api/cron/deal-alerts",     "schedule": "0 23 * * *" },
     { "path": "/api/cron/leaderboard",     "schedule": "0 0 * * *"  },
-    { "path": "/api/cron/ozbargain-parse", "schedule": "0 */6 * * *" },
+    { "path": "/api/cron/ozbargain-parse", "schedule": "0 4 * * *" },
     { "path": "/api/cron/cdr-refresh",     "schedule": "0 16 * * 0" },
     { "path": "/api/cron/card-extract",    "schedule": "0 17 * * 0"  }
   ]


### PR DESCRIPTION
## Summary
- **CI fix**: `vercel.json` ozbargain-parse cron changed from `0 */6 * * *` (every 6h, blocked by Hobby plan) to `0 4 * * *` (daily 4am UTC) — this was blocking ALL deployments
- **Tailwind theme**: Added all Financial Luminary surface/color tokens to `@theme inline` in globals.css so utility classes like `bg-surface-container`, `bg-surface-container-low`, `text-on-surface` etc. now generate correctly
- **Error pages**: `error.tsx` and `global-error.tsx` updated from light `bg-white/bg-gray` to dark Financial Luminary palette (`#0f131f`/`#1b1f2c`) with emerald CTA button

## Root cause of CI failures
The `0 */6 * * *` cron schedule (runs 4× per day) violates Vercel Hobby plan's daily-only restriction. Every push to master triggered this error, preventing any deployment. This is the core blocker.

## Test plan
- [ ] CI passes (no Vercel cron error)
- [ ] Production deploys to rewardrelay.app
- [ ] Tailwind classes `bg-surface-container`, `bg-surface-container-low` etc. render with correct dark colors
- [ ] Error page shows dark background on error