### PR TITLE
fix(design): dark theme for cards catalog + remaining pages

### DIFF
--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -77,6 +77,8 @@
   --warning-fg: #fbbf24;
   --info-bg: rgba(192, 188, 255, 0.12);
   --info-fg: #c3c0ff;
+  --accent-bg: rgba(78, 222, 163, 0.15);
+  --accent-fg: #4edea3;
 
   /* ─── Charts ─── */
   --chart-1: #4edea3;


### PR DESCRIPTION
## Summary

- Audited cards catalog, recommendations, compare, and dashboard pages — all correctly use the Financial Luminary dark token system (CSS variables + explicit hex values), no light-background regressions found
- Added missing `--accent-bg` and `--accent-fg` design tokens to `tokens.css`, used by the Top Pick badge on the recommendations and projections pages

## Test plan

- [ ] Visit /cards — dark surface, green accents on welcome bonus, dark filter bar
- [ ] Visit /recommendations — dark stat cards, dark filter & sort panel, Top Pick badge renders with correct accent green colour
- [ ] Visit /compare — dark stat cards, dark card rankings list, eligibility badges themed correctly
- [ ] Visit /dashboard — dark hero metric block, dark stat tiles, dark wallet cards
- [ ] Top Pick / accent badges in recommendations and projections use `--accent-bg` / `--accent-fg` without falling back to defaults

Closes #163.