### PR TITLE
fix(tokens): expose Financial Luminary palette + font-headline as Tailwind utilities

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -8,6 +8,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-grotesk);
+  --font-headline: var(--font-grotesk);
   --font-mono: var(--font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -38,6 +39,32 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+
+  /* ─── Financial Luminary design system tokens → Tailwind utilities ─── */
+  --color-surface: var(--surface);
+  --color-surface-dim: var(--surface-dim);
+  --color-surface-container-lowest: var(--surface-container-lowest);
+  --color-surface-container-low: var(--surface-container-low);
+  --color-surface-container: var(--surface-container);
+  --color-surface-container-high: var(--surface-container-high);
+  --color-surface-container-highest: var(--surface-container-highest);
+  --color-surface-bright: var(--surface-bright);
+  --color-on-surface: var(--on-surface);
+  --color-on-surface-variant: var(--on-surface-variant);
+  --color-on-background: var(--on-background);
+  --color-on-primary: var(--on-primary);
+  --color-primary-container: var(--primary-container);
+  --color-primary-fixed: var(--primary-fixed);
+  --color-primary-fixed-dim: var(--primary-fixed-dim);
+  --color-secondary-container: var(--secondary-container);
+  --color-on-secondary-container: var(--on-secondary-container);
+  --color-tertiary: var(--tertiary);
+  --color-tertiary-container: var(--tertiary-container);
+  --color-outline: var(--outline);
+  --color-outline-variant: var(--outline-variant);
+  --color-error-container: var(--error-container);
+  --color-surface-tint: var(--surface-tint);
+
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -191,6 +218,11 @@
   }
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
+  }
+
+  /* Safe-area bottom padding for mobile nav */
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom, 0.25rem);
   }
 }
 


### PR DESCRIPTION
## Summary

Restores Financial Luminary design system tokens as Tailwind utility classes (lost when dc12891 overwrote globals.css) and adds two new capabilities:

- **Financial Luminary tokens**: `bg-surface-container`, `bg-surface-container-low`, `text-on-surface`, `text-on-surface-variant`, `bg-primary-container`, `text-outline`, `text-outline-variant` etc. now generate as Tailwind utility classes
- **font-headline**: `--font-headline` alias added so `font-headline` class resolves to Plus Jakarta Sans (required by WalletCard.tsx and upcoming nav work)
- **pb-safe**: New utility for iOS safe-area bottom inset on mobile nav

## Root cause
Commit dc12891 cherry-picked globals.css from a branch predating PR #173, silently removing ~25 lines from the @theme inline block.

## Test plan
- [ ] CI passes
- [ ] bg-surface-container renders background-color: #1b1f2c
- [ ] font-headline applies Plus Jakarta Sans