### PR TITLE
fix(nav): fixed sidebar + flat nav taxonomy + Financial Luminary active states

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#f8fafc" },
-    { media: "(prefers-color-scheme: dark)", color: "#0a0a0b" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f131f" },
   ],
 }
 

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -3,80 +3,24 @@
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { toast } from "sonner"
-import {
-  Home,
-  CreditCard,
-  LogOut,
-  Sparkles,
-  Wallet,
-  CalendarDays,
-  Compass,
-  ChevronRight,
-  TrendingUp,
-  Upload,
-  History,
-  Scale,
-  Lightbulb,
-  Calendar,
-} from "lucide-react"
-import { useMemo, useState } from "react"
+import { Home, CreditCard, Wallet, Plane, User, LogOut, Sparkles } from "lucide-react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase/client"
-
-type NavChild = {
-  href: string
-  label: string
-  icon: React.ComponentType<{ className?: string }>
-}
 
 type NavItem = {
   href: string
   label: string
   icon: React.ComponentType<{ className?: string }>
-  children?: NavChild[]
 }
 
 const navItems: NavItem[] = [
-  {
-    href: "/dashboard",
-    label: "Home",
-    icon: Home,
-  },
-  {
-    href: "/cards",
-    label: "Cards",
-    icon: CreditCard,
-  },
-  {
-    href: "/recommendations",
-    label: "Discover",
-    icon: Compass,
-    children: [
-      { href: "/recommendations", label: "Recommendations", icon: Lightbulb },
-      { href: "/compare", label: "Compare", icon: Scale },
-      { href: "/projections", label: "Projections", icon: TrendingUp },
-    ],
-  },
-  {
-    href: "/spending",
-    label: "Spending",
-    icon: Wallet,
-    children: [
-      { href: "/spending", label: "Tracker", icon: Wallet },
-      { href: "/profit", label: "Profit Dashboard", icon: TrendingUp },
-      { href: "/statements", label: "Import Statements", icon: Upload },
-    ],
-  },
-  {
-    href: "/calendar",
-    label: "Timeline",
-    icon: CalendarDays,
-    children: [
-      { href: "/calendar", label: "Calendar", icon: Calendar },
-      { href: "/history", label: "History", icon: History },
-    ],
-  },
+  { label: "Home",    href: "/dashboard", icon: Home       },
+  { label: "Cards",   href: "/cards",     icon: CreditCard },
+  { label: "Track",   href: "/spending",  icon: Wallet     },
+  { label: "Redeem",  href: "/flights",   icon: Plane      },
+  { label: "Account", href: "/settings",  icon: User       },
 ]
 
 type AppShellProps = {
@@ -87,23 +31,13 @@ export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname()
   const router = useRouter()
   const [signingOut, setSigningOut] = useState(false)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
 
-  const navMap = useMemo(() => {
-    return navItems.map((item) => {
-      const isParentActive = pathname.startsWith(item.href)
-      const isChildActive = item.children?.some((c) => pathname.startsWith(c.href)) ?? false
-      const active = isParentActive || isChildActive
-
-      return {
-        ...item,
-        active,
-        children: item.children?.map((child) => ({
-          ...child,
-          active: pathname.startsWith(child.href),
-        })),
-      }
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUserEmail(data.user?.email ?? null)
     })
-  }, [pathname])
+  }, [])
 
   const handleSignOut = async () => {
     setSigningOut(true)
@@ -116,129 +50,158 @@ export function AppShell({ children }: AppShellProps) {
     router.replace("/")
   }
 
-  return (
-    <div className="min-h-screen bg-[var(--surface-muted)]">
-      {/* Header */}
-      <header className="sticky top-0 z-20 border-b border-[var(--border-default)] bg-[var(--surface)]/90 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-3">
-          <Link href="/dashboard" className="flex items-center gap-2.5">
-            <div
-              className="flex h-8 w-8 items-center justify-center rounded-xl text-white shadow-sm"
-              style={{ background: "var(--gradient-cta)" }}
-            >
-              <Sparkles className="h-4 w-4" />
-            </div>
-            <span className="text-sm font-semibold text-[var(--text-primary)]">Reward Relay</span>
-          </Link>
+  const isActive = (href: string) => pathname.startsWith(href)
 
-          <div className="ml-auto flex items-center gap-2">
-            <Button
-              size="sm"
-              className="hidden rounded-full text-white shadow-sm md:inline-flex"
-              style={{ background: "var(--gradient-cta)" }}
-              onClick={() => router.push("/cards")}
-            >
-              <CreditCard className="mr-1.5 h-3.5 w-3.5" />
-              Add card
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleSignOut}
-              disabled={signingOut}
-              className="text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-              title="Sign out"
-            >
-              <LogOut className="h-4 w-4" />
-            </Button>
+  return (
+    <div className="min-h-screen" style={{ background: "var(--surface)" }}>
+      {/* ── Desktop fixed sidebar ── */}
+      <aside
+        className="hidden md:flex fixed left-0 top-0 h-screen w-64 flex-col z-30"
+        style={{ background: "#171b28", borderRight: "1px solid rgba(255,255,255,0.05)" }}
+      >
+        {/* Logo */}
+        <div className="flex items-center gap-2.5 px-5 py-5">
+          <div
+            className="flex h-8 w-8 items-center justify-center rounded-xl text-white shadow-sm flex-shrink-0"
+            style={{ background: "var(--gradient-cta)" }}
+          >
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold" style={{ color: "var(--primary)" }}>
+              Reward Relay
+            </p>
+            <p className="text-[10px] uppercase tracking-widest" style={{ color: "rgba(148,163,184,0.6)" }}>
+              The Financial Luminary
+            </p>
           </div>
         </div>
-      </header>
 
-      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 px-4 py-6 pb-24 md:grid-cols-[220px_1fr] md:pb-6">
-        {/* Desktop Sidebar */}
-        <aside className="hidden h-fit md:block">
-          <nav className="rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-2 shadow-sm">
-            {navMap.map((item) => {
-              const Icon = item.icon
-              const hasChildren = !!(item.children && item.children.length > 0)
-              const showChildren = hasChildren && item.active
-
-              return (
-                <div key={item.href}>
-                  <Link
-                    href={item.href}
-                    className={`flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
-                      item.active
-                        ? "bg-[var(--surface-strong)] text-[var(--text-primary)]"
-                        : "text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)] hover:text-[var(--text-primary)]"
-                    }`}
-                  >
-                    <Icon
-                      className={`h-4 w-4 flex-shrink-0 ${
-                        item.active ? "text-[var(--accent)]" : ""
-                      }`}
-                    />
-                    <span className="flex-1">{item.label}</span>
-                    {hasChildren && (
-                      <ChevronRight
-                        className={`h-3.5 w-3.5 transition-transform ${
-                          item.active
-                            ? "rotate-90 text-[var(--text-secondary)]"
-                            : "text-[var(--text-secondary)]/40"
-                        }`}
-                      />
-                    )}
-                  </Link>
-
-                  {/* Sub-items: shown when parent is active */}
-                  {showChildren && item.children && (
-                    <div className="mb-1 ml-4 space-y-0.5 border-l border-[var(--border-default)] pl-2.5 pt-0.5">
-                      {item.children.map((child) => {
-                        const ChildIcon = child.icon
-                        return (
-                          <Link
-                            key={child.href}
-                            href={child.href}
-                            className={`flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition-colors ${
-                              child.active
-                                ? "bg-[var(--surface-strong)] font-medium text-[var(--text-primary)]"
-                                : "text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)] hover:text-[var(--text-primary)]"
-                            }`}
-                          >
-                            <ChildIcon className="h-3.5 w-3.5 flex-shrink-0" />
-                            {child.label}
-                          </Link>
-                        )
-                      })}
-                    </div>
-                  )}
-                </div>
-              )
-            })}
-          </nav>
-        </aside>
-
-        <main className="min-w-0 space-y-5">{children}</main>
-      </div>
-
-      {/* Mobile Bottom Nav — exactly 5 items, no scroll */}
-      <nav className="fixed inset-x-0 bottom-0 z-20 border-t border-[var(--border-default)] bg-[var(--surface)]/95 backdrop-blur md:hidden">
-        <div className="mx-auto grid max-w-sm grid-cols-5 px-2 py-1">
-          {navMap.map((item) => {
-            const Icon = item.icon
+        {/* Nav */}
+        <nav className="flex-1 px-3 py-2 space-y-0.5">
+          {navItems.map(({ href, label, icon: Icon }) => {
+            const active = isActive(href)
             return (
-              <button
-                key={item.href}
-                onClick={() => router.push(item.href)}
-                className={`flex flex-col items-center gap-1 rounded-lg px-1 py-2 transition-colors ${
-                  item.active
-                    ? "text-[var(--accent)]"
-                    : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+              <Link
+                key={href}
+                href={href}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                  active
+                    ? "bg-surface-container text-primary"
+                    : "text-slate-400 hover:bg-surface-container-highest hover:text-on-surface"
                 }`}
               >
-                <Icon className="h-5 w-5 flex-shrink-0" />
-                <span className="text-[10px] font-medium leading-tight">{item.label}</span>
+                <Icon className={`h-4 w-4 flex-shrink-0 ${active ? "scale-110" : ""}`} />
+                {label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        {/* Sidebar footer */}
+        <div className="px-3 pb-5 space-y-3">
+          {/* User info */}
+          {userEmail && (
+            <div className="flex items-center gap-2.5 px-2 py-1.5">
+              <div
+                className="flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold flex-shrink-0"
+                style={{ background: "var(--primary-container)", color: "var(--on-primary)" }}
+              >
+                {userEmail[0].toUpperCase()}
+              </div>
+              <p className="text-xs truncate" style={{ color: "rgba(148,163,184,0.7)" }}>
+                {userEmail}
+              </p>
+            </div>
+          )}
+
+          {/* "The Financial Luminary" label */}
+          <p className="text-[10px] uppercase tracking-widest px-2" style={{ color: "rgba(148,163,184,0.4)" }}>
+            The Financial Luminary
+          </p>
+
+          {/* Add New Card pill */}
+          <button
+            onClick={() => router.push("/cards")}
+            className="w-full rounded-full py-2 px-4 text-sm font-semibold transition-opacity hover:opacity-90"
+            style={{ background: "var(--gradient-cta)", color: "#003824" }}
+          >
+            + Add New Card
+          </button>
+
+          {/* Sign out */}
+          <button
+            onClick={handleSignOut}
+            disabled={signingOut}
+            className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-lg transition-colors hover:bg-white/5 disabled:opacity-50"
+            style={{ color: "rgba(148,163,184,0.5)" }}
+          >
+            <LogOut className="h-4 w-4 flex-shrink-0" />
+            {signingOut ? "Signing out…" : "Sign out"}
+          </button>
+        </div>
+      </aside>
+
+      {/* ── Mobile header ── */}
+      <header
+        className="sticky top-0 z-20 flex items-center justify-between px-4 py-3 md:hidden"
+        style={{
+          background: "rgba(23,27,40,0.95)",
+          backdropFilter: "blur(12px)",
+          borderBottom: "1px solid rgba(255,255,255,0.05)",
+        }}
+      >
+        <Link href="/dashboard" className="flex items-center gap-2">
+          <div
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-white"
+            style={{ background: "var(--gradient-cta)" }}
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+          </div>
+          <span className="text-sm font-semibold" style={{ color: "var(--primary)" }}>
+            Reward Relay
+          </span>
+        </Link>
+        <Button
+          size="sm"
+          className="rounded-full text-[#003824] text-xs font-semibold px-4"
+          style={{ background: "var(--gradient-cta)" }}
+          onClick={() => router.push("/cards")}
+        >
+          Add card
+        </Button>
+      </header>
+
+      {/* ── Page content ── */}
+      <div className="md:pl-64 pb-24 md:pb-6">
+        <main className="min-w-0">{children}</main>
+      </div>
+
+      {/* ── Mobile bottom nav ── */}
+      <nav
+        className="fixed inset-x-0 bottom-0 z-20 md:hidden"
+        style={{
+          background: "rgba(23,27,40,0.97)",
+          backdropFilter: "blur(12px)",
+          borderTop: "1px solid rgba(255,255,255,0.05)",
+          boxShadow: "0 -8px 32px rgba(0,0,0,0.5)",
+        }}
+      >
+        <div className="grid grid-cols-5 pb-safe">
+          {navItems.map(({ href, label, icon: Icon }) => {
+            const active = isActive(href)
+            return (
+              <button
+                key={href}
+                onClick={() => router.push(href)}
+                className={`flex flex-col items-center gap-1 py-2 px-1 transition-colors active:bg-white/5 ${
+                  active ? "text-primary" : "text-slate-400"
+                }`}
+              >
+                <Icon className={`h-5 w-5 flex-shrink-0 transition-transform ${active ? "scale-110" : ""}`} />
+                <span className="text-[9px] font-semibold tracking-widest uppercase leading-tight">
+                  {label}
+                </span>
               </button>
             )
           })}


### PR DESCRIPTION
## Summary

- **NAV-001**: Fixed `w-64` left sidebar (`position: fixed`) replacing header+grid layout; `md:pl-64` content offset; `#171b28` background, `border-white/5` ghost border
- **NAV-002**: Flat 5-item nav — Home / Cards / Track / Redeem / Account — no sub-items, no ChevronRight, no nested taxonomy
- **NAV-003**: Active state uses `bg-surface-container text-primary` (Tailwind token classes from TOKEN-001)
- **NAV-004**: Sidebar footer with "The Financial Luminary" tagline, "Add New Card" gradient pill CTA, sign-out button
- **NAV-005**: No card wrapper border on sidebar — background contrast only
- **NAV-006**: Fix `theme-color` meta for dark mode: `#0a0a0b` → `#0f131f`
- Mobile: sticky header (brand + Add card), bottom nav with `pb-safe`, `scale-110` active icon, `font-semibold tracking-widest` labels, `shadow-[0_-8px_32px_rgba(0,0,0,0.5)]`

## Test plan

- [ ] Desktop: fixed sidebar visible, content shifts right 256px (`md:pl-64`)
- [ ] Active nav item shows emerald text + `surface-container` bg
- [ ] Sidebar footer visible: tagline, Add New Card pill, sign-out link
- [ ] Mobile: top header with brand name + Add card button
- [ ] Mobile bottom nav: all 5 items, active item has `scale-110` icon + emerald color
- [ ] Sign-out from sidebar footer redirects to `/`
- [ ] No sub-menus expand on nav click