### PR TITLE
fix(components): WalletCard shadow/hover + pill buttons + input dark bg

### DIFF
--- a/app/src/components/ui/WalletCard.tsx
+++ b/app/src/components/ui/WalletCard.tsx
@@ -37,7 +37,7 @@ export function WalletCard({ card, showProgress = false, onClick }: Props) {
     >
       {/* Card face */}
       <div
-        className="relative aspect-[1.586/1] w-full rounded-xl p-6 flex flex-col justify-between shadow-2xl transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-lg overflow-hidden"
+        className="relative aspect-[1.586/1] w-full rounded-xl p-6 flex flex-col justify-between overflow-hidden shadow-[0px_24px_48px_-12px_rgba(0,0,0,0.4)] transition-transform duration-300 group-hover:-translate-y-2"
         style={{ background: gradient }}
       >
         {/* Subtle overlay */}
@@ -62,26 +62,20 @@ export function WalletCard({ card, showProgress = false, onClick }: Props) {
             </p>
           )}
         </div>
-      </div>
 
-      {/* Progress bar below card (compact) */}
-      {showProgress && progressPct !== null && (
-        <div className="mt-3 px-1 space-y-1">
-          <div className="flex justify-between text-[10px] font-medium text-slate-400">
-            <span>Spend progress</span>
-            <span className="tabular-nums text-[#4edea3]">{progressPct}%</span>
-          </div>
-          <div className="h-1 w-full rounded-full bg-[#313442] overflow-hidden">
+        {/* Progress bar — embedded at bottom of card face */}
+        {showProgress && progressPct !== null && (
+          <div className="absolute bottom-0 inset-x-0 h-1.5 z-20">
             <div
-              className="h-full rounded-full transition-all duration-700"
+              className="h-full transition-all duration-700"
               style={{
                 width: `${progressPct}%`,
                 background: "linear-gradient(90deg, #10b981 0%, #4edea3 100%)",
               }}
             />
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/app/src/components/ui/button.tsx
+++ b/app/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface)] aria-invalid:ring-destructive/30 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-semibold transition-all active:scale-95 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface)] aria-invalid:ring-destructive/30 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -23,8 +23,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 px-6 has-[>svg]:px-4",
         icon: "size-9",
         "icon-sm": "size-8",
         "icon-lg": "size-10",

--- a/app/src/components/ui/input.tsx
+++ b/app/src/components/ui/input.tsx
@@ -8,8 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "bg-[var(--surface-container-highest)]",
+        "focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-[var(--primary)]/20",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}


### PR DESCRIPTION
## Summary

- **CARDS-001**: WalletCard gets `shadow-[0px_24px_48px_-12px_rgba(0,0,0,0.4)]`, `hover:-translate-y-2 transition-transform duration-300`; spend progress bar moved inside card face as `absolute bottom-0 h-1.5` strip (external progress div removed)
- **BUTTON-001**: Base `rounded-md` → `rounded-full`; `active:scale-95` press state added; size variant `rounded-md` overrides removed so pill shape is consistent
- **INPUT-001**: `bg-transparent` → `bg-[var(--surface-container-highest)]`; focus ring `ring-[3px] ring-ring/50` → `ring-1 ring-[var(--primary)]/20`

## Test plan

- [ ] WalletCard: deep shadow visible; card lifts `-translate-y-2` on hover; progress bar appears as thin strip flush with card bottom edge (no external element)
- [ ] All buttons render with pill/rounded-full shape; press triggers `scale-95` shrink
- [ ] Inputs have dark surface bg (`surface-container-highest`); focus shows single emerald ghost ring