### PR TITLE
feat(spending): glassmorphism stat cards + input border fix + flights No-Line cleanup

### DIFF
--- a/app/src/app/flights/page.tsx
+++ b/app/src/app/flights/page.tsx
@@ -250,27 +250,25 @@ export default function FlightsPage() {
 
             {/* Not found fallback */}
             {searchNotFound && (
-              <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-                <CardContent className="py-6 text-center">
-                  <Plane className="mx-auto mb-3 h-7 w-7 text-[var(--text-secondary)]/40" />
-                  <p className="text-sm font-medium text-[var(--text-primary)]">
-                    Route not in our database
-                  </p>
-                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                    Check{' '}
-                    <a
-                      href="https://www.qantas.com/us/en/frequent-flyer/use-points/classic-flight-rewards.html"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-0.5 text-[var(--accent)] hover:underline"
-                    >
-                      qantas.com
-                      <ExternalLink className="h-3 w-3" />
-                    </a>{' '}
-                    for the full zone chart.
-                  </p>
-                </CardContent>
-              </Card>
+              <div className="glass-panel rounded-2xl py-6 text-center">
+                <Plane className="mx-auto mb-3 h-7 w-7 text-[var(--text-secondary)]/40" />
+                <p className="text-sm font-medium text-[var(--text-primary)]">
+                  Route not in our database
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  Check{' '}
+                  <a
+                    href="https://www.qantas.com/us/en/frequent-flyer/use-points/classic-flight-rewards.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-0.5 text-[var(--accent)] hover:underline"
+                  >
+                    qantas.com
+                    <ExternalLink className="h-3 w-3" />
+                  </a>{' '}
+                  for the full zone chart.
+                </p>
+              </div>
             )}
 
             {/* Show all Qantas routes when no search active */}
@@ -297,17 +295,15 @@ export default function FlightsPage() {
 
           {/* No balances empty state */}
           {!hasBalances && (
-            <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-              <CardContent className="py-12 text-center">
-                <Plane className="mx-auto mb-3 h-8 w-8 text-[var(--text-secondary)]" />
-                <p className="text-sm font-medium text-[var(--text-primary)]">
-                  No loyalty balances found
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Add your loyalty balances to see what you can book
-                </p>
-              </CardContent>
-            </Card>
+            <div className="glass-panel rounded-2xl py-12 text-center">
+              <Plane className="mx-auto mb-3 h-8 w-8 text-[var(--text-secondary)]" />
+              <p className="text-sm font-medium text-[var(--text-primary)]">
+                No loyalty balances found
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Add your loyalty balances to see what you can book
+              </p>
+            </div>
           )}
 
           {/* Filters + Amex toggle */}
@@ -352,7 +348,7 @@ export default function FlightsPage() {
               </Select>
 
               {/* Amex MR toggle */}
-              <label className="ml-auto flex cursor-pointer items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)]">
+              <label className="ml-auto flex cursor-pointer items-center gap-2 rounded-lg border border-white/5 bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)]">
                 <input
                   type="checkbox"
                   checked={includeAmexTransfers}
@@ -410,13 +406,11 @@ export default function FlightsPage() {
 
           {/* Empty filtered state */}
           {filtered.length === 0 && hasBalances && (
-            <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
-              <CardContent className="py-12 text-center">
-                <p className="text-sm text-[var(--text-secondary)]">
-                  No routes match your filters.
-                </p>
-              </CardContent>
-            </Card>
+            <div className="glass-panel rounded-2xl py-12 text-center">
+              <p className="text-sm text-[var(--text-secondary)]">
+                No routes match your filters.
+              </p>
+            </div>
           )}
         </section>
       </div>

--- a/app/src/app/spending/page.tsx
+++ b/app/src/app/spending/page.tsx
@@ -344,6 +344,75 @@ export default function SpendingTrackerPage() {
 
             {activeCard && pace && (
               <>
+                {/* ── 4-column glassmorphism stat cards ── */}
+                {(() => {
+                  const daysLeft = activeCard.spend_deadline
+                    ? Math.max(0, Math.ceil((new Date(activeCard.spend_deadline).getTime() - Date.now()) / 86400000))
+                    : null
+                  const remaining = Math.max(0, activeCard.spend_target - activeCard.current_spend)
+                  const dailyPace = daysLeft && daysLeft > 0 ? remaining / daysLeft : null
+                  const pct = activeCard.spend_target > 0
+                    ? Math.min(100, Math.round((activeCard.current_spend / activeCard.spend_target) * 100))
+                    : 0
+                  const bonusPts = activeCard.card.welcome_bonus_points
+
+                  const stats = [
+                    {
+                      label: "Est. Rewards",
+                      value: bonusPts ? `${(bonusPts / 1000).toFixed(0)}k pts` : "—",
+                      sub: "if target hit",
+                      icon: "✦",
+                      accent: true,
+                    },
+                    {
+                      label: "Time Remaining",
+                      value: daysLeft !== null ? `${daysLeft}d` : "—",
+                      sub: "until deadline",
+                      icon: "◷",
+                      accent: daysLeft !== null && daysLeft < 14,
+                    },
+                    {
+                      label: "Daily Pace",
+                      value: dailyPace !== null ? `$${Math.ceil(dailyPace)}/d` : "—",
+                      sub: "needed to hit bonus",
+                      icon: "⚡",
+                      accent: false,
+                    },
+                    {
+                      label: "Bonus Progress",
+                      value: `${pct}%`,
+                      sub: `$${Math.round(activeCard.current_spend).toLocaleString()} of $${Math.round(activeCard.spend_target).toLocaleString()}`,
+                      icon: "◎",
+                      accent: pct >= 100,
+                    },
+                  ]
+
+                  return (
+                    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                      {stats.map((s) => (
+                        <div key={s.label} className="glass-panel rounded-2xl p-4">
+                          <div className="flex items-center justify-between">
+                            <p className="text-[10px] font-bold uppercase tracking-widest text-[#bbcabf]">
+                              {s.label}
+                            </p>
+                            <span className="text-[#4edea3]/40 text-sm">{s.icon}</span>
+                          </div>
+                          <p
+                            className="mt-2 text-2xl font-black tabular-nums"
+                            style={{
+                              fontFamily: "'Plus Jakarta Sans', sans-serif",
+                              color: s.accent ? "#4edea3" : "#dfe2f3",
+                            }}
+                          >
+                            {s.value}
+                          </p>
+                          <p className="mt-0.5 text-[11px] text-[#bbcabf]">{s.sub}</p>
+                        </div>
+                      ))}
+                    </div>
+                  )
+                })()}
+
                 {/* Arc + stats */}
                 <div className="flex flex-col gap-5 rounded-b-[4rem] md:flex-row md:items-center">
                   {/* Arc — 60% width */}

--- a/app/src/components/ui/input.tsx
+++ b/app/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 rounded-md px-3 py-1 text-base outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "bg-[var(--surface-container-highest)]",
         "focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-[var(--primary)]/20",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",


### PR DESCRIPTION
## Summary

- **SPEND-001**: 4-column glassmorphism stat card row added above spend arc on `/spending` — Est. Rewards (welcome bonus pts if target hit), Time Remaining (days to deadline), Daily Pace (\$/day needed), Bonus Progress (% of target hit). Values accent-coloured when thresholds are critical.
- **INPUT-001**: Removed `border border-input` from `input.tsx` base class — eliminates No-Line Rule violation. Background separation via existing `bg-[var(--surface-container-highest)]`. Focus ring retained.
- **NOLINEV-001**: Replaced 3 remaining `<Card className="border border-[var(--border-default)]">` empty/not-found state cards on `/flights` with borderless `glass-panel` divs. Amex toggle label border softened to `border-white/5` (ghost, ≤5% opacity — compliant).

## Test plan

- [ ] `/spending` with active cards shows 4 stat cards above arc: Est. Rewards, Time Remaining, Daily Pace, Bonus Progress
- [ ] Stat values correctly computed from activeCard data (pts, days, $/day, %)
- [ ] Input fields across app have no visible border — background shift only
- [ ] `/flights` "not found", "no balances", and "empty filters" states render as glass panels without hard borders
- [ ] TypeScript compiles clean