### PR TITLE
fix(tokens): replace hardcoded hex with CSS vars + dashboard portfolio metric

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -113,7 +113,8 @@ export default function DashboardPage() {
       }
     }
 
-    return { active, pending, total: cards.length, bonusReady, totalPoints, monthlyPoints }
+    const portfolioValue = totalPoints * 0.02 // 2¢ per point — AUD monetary value of earned bonuses
+    return { active, pending, total: cards.length, bonusReady, totalPoints, monthlyPoints, portfolioValue }
   }, [cards, catalogCards])
 
   const cancelAlerts = useMemo(() => {
@@ -194,15 +195,26 @@ export default function DashboardPage() {
 
         {/* Hero metric */}
         <div className="rounded-2xl bg-surface-container p-8">
-          <p className="text-xs font-semibold uppercase tracking-widest text-on-surface-variant">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
             {displayName ? `Hey, ${displayName}` : "Dashboard"}
           </p>
-          <div className="mt-3 flex items-baseline gap-4">
-            <span className="font-headline text-6xl font-extrabold tabular-nums tracking-tighter text-primary">
-              {stats.active}
-            </span>
-            <span className="text-base text-on-surface-variant">cards working for you</span>
-          </div>
+          {stats.portfolioValue > 0 ? (
+            <div className="mt-3 flex items-baseline gap-3">
+              <span className="font-headline text-6xl font-extrabold tabular-nums tracking-tighter text-primary">
+                ${stats.portfolioValue.toLocaleString("en-AU", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+              </span>
+              <span className="text-base text-on-surface-variant">total portfolio value</span>
+            </div>
+          ) : (
+            <div className="mt-3 flex items-baseline gap-4">
+              <span className="font-headline text-6xl font-extrabold tabular-nums tracking-tighter text-primary">
+                {stats.active}
+              </span>
+              <span className="text-base text-on-surface-variant">
+                {stats.active === 1 ? "card" : "cards"} working for you
+              </span>
+            </div>
+          )}
           <Button
             size="sm"
             className="mt-6 rounded-full font-semibold text-on-primary shadow-sm"

--- a/app/src/components/cards/CardFilters.tsx
+++ b/app/src/components/cards/CardFilters.tsx
@@ -19,10 +19,10 @@ export function CardFilters({ cards, onFilter }: CardFilterProps) {
   )
 
   return (
-    <div className="flex flex-col gap-4 rounded-2xl bg-[#1b1f2c] p-4 text-white shadow-md md:flex-row md:items-center md:justify-between">
+    <div className="flex flex-col gap-4 rounded-2xl bg-surface-container p-4 text-on-surface shadow-md md:flex-row md:items-center md:justify-between">
       <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Filters</p>
-        <p className="text-sm text-slate-300">{cards.length} cards available</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-on-surface-variant">Filters</p>
+        <p className="text-sm text-on-surface-variant">{cards.length} cards available</p>
       </div>
       <div className="flex flex-col gap-3 md:flex-row md:items-center">
         <Input
@@ -33,7 +33,7 @@ export function CardFilters({ cards, onFilter }: CardFilterProps) {
             setSearch(value)
             onFilter({ search: value, bank })
           }}
-          className="rounded-xl border-0 bg-[#313442] text-[#dfe2f3] placeholder:text-slate-500 focus-visible:bg-[#353946] focus-visible:ring-0 md:w-80"
+          className="rounded-xl border-0 bg-surface-container-highest text-on-surface placeholder:text-on-surface-variant/50 focus-visible:bg-surface-bright focus-visible:ring-0 md:w-80"
         />
         <Select
           onValueChange={(value) => {
@@ -43,7 +43,7 @@ export function CardFilters({ cards, onFilter }: CardFilterProps) {
           }}
           defaultValue="all"
         >
-          <SelectTrigger className="w-full rounded-xl border-0 bg-[#313442] text-[#dfe2f3] focus:ring-0 md:w-48">
+          <SelectTrigger className="w-full rounded-xl border-0 bg-surface-container-highest text-on-surface focus:ring-0 md:w-48">
             <SelectValue placeholder="Filter by bank" />
           </SelectTrigger>
           <SelectContent>

--- a/app/src/components/cards/CardItem.tsx
+++ b/app/src/components/cards/CardItem.tsx
@@ -10,19 +10,19 @@ export type CardRecord = {
 
 export function CardItem({ card }: { card: CardRecord }) {
   return (
-    <div className="flex flex-col gap-4 rounded-2xl bg-[#1b1f2c] p-6 shadow-md transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg">
+    <div className="flex flex-col gap-4 rounded-2xl bg-surface-container p-6 shadow-md transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg">
       {/* Header */}
       <div className="flex items-start justify-between gap-3">
-        <span className="rounded-full bg-[#571bc1]/20 px-3 py-1 text-xs font-semibold text-[#d0bcff]">
+        <span className="rounded-full bg-secondary/10 px-3 py-1 text-xs font-semibold text-secondary">
           {card.bank}
         </span>
-        <span className="rounded-full bg-[#4edea3]/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#4edea3]">
+        <span className="rounded-full bg-primary/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-primary">
           {card.points_currency || "Points"}
         </span>
       </div>
 
       {/* Card name */}
-      <h3 className="text-base font-semibold leading-tight text-[#dfe2f3]">{card.name}</h3>
+      <h3 className="text-base font-semibold leading-tight text-on-surface">{card.name}</h3>
 
       {/* Primary metrics */}
       <div className="grid grid-cols-2 gap-3">
@@ -43,15 +43,15 @@ export function CardItem({ card }: { card: CardRecord }) {
       </div>
 
       {card.min_income != null && (
-        <p className="text-[10px] font-medium text-slate-500">
+        <p className="text-[10px] font-medium text-on-surface-variant">
           Min income: ${card.min_income.toLocaleString()}
         </p>
       )}
 
       {/* CTA */}
       <button
-        className="mt-1 w-full rounded-xl py-2.5 text-sm font-bold text-[#003824] transition-opacity hover:opacity-90 active:opacity-75"
-        style={{ background: "linear-gradient(135deg, #4edea3 0%, #10b981 100%)" }}
+        className="mt-1 w-full rounded-xl py-2.5 text-sm font-bold text-on-primary transition-opacity hover:opacity-90 active:opacity-75"
+        style={{ background: "var(--gradient-cta)" }}
       >
         Add card
       </button>
@@ -69,11 +69,11 @@ function MetricBox({
   highlight: boolean
 }) {
   return (
-    <div className="rounded-xl bg-[#313442] px-3 py-2.5">
-      <p className="text-[9px] font-bold uppercase tracking-wider text-slate-500">{label}</p>
+    <div className="rounded-xl bg-surface-container-highest px-3 py-2.5">
+      <p className="text-[9px] font-bold uppercase tracking-wider text-on-surface-variant">{label}</p>
       <p
         className={`mt-0.5 text-sm font-bold tabular-nums ${
-          highlight ? "text-[#4edea3]" : "text-[#dfe2f3]"
+          highlight ? "text-primary" : "text-on-surface"
         }`}
       >
         {value}

--- a/app/src/components/layout/Header.tsx
+++ b/app/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ function LogoContent() {
 
 export default function Header({ logoClickable = false }: HeaderProps) {
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-[#0a0e1a]/80 backdrop-blur-xl">
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-surface-container-lowest/80 backdrop-blur-xl">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
         {logoClickable ? (
           <Link href="/" className="flex items-center gap-3 transition-opacity hover:opacity-80">
@@ -44,8 +44,8 @@ export default function Header({ logoClickable = false }: HeaderProps) {
               href="/signup"
               className="inline-flex items-center justify-center rounded-full px-6 py-2 text-sm font-semibold transition-all hover:scale-105"
               style={{
-                background: "linear-gradient(135deg, #4edea3 0%, #10b981 100%)",
-                color: "#003824",
+                background: "var(--gradient-cta)",
+                color: "var(--on-primary)",
                 boxShadow: "0 4px 16px rgba(78, 222, 163, 0.25)",
               }}
             >

--- a/app/src/components/ui/WalletCard.tsx
+++ b/app/src/components/ui/WalletCard.tsx
@@ -70,7 +70,7 @@ export function WalletCard({ card, showProgress = false, onClick }: Props) {
               className="h-full transition-all duration-700"
               style={{
                 width: `${progressPct}%`,
-                background: "linear-gradient(90deg, #10b981 0%, #4edea3 100%)",
+                background: "linear-gradient(90deg, var(--primary-container) 0%, var(--primary) 100%)",
               }}
             />
           </div>


### PR DESCRIPTION
## Summary

- **TOKEN-002**: Purge hardcoded hex values from `WalletCard.tsx`, `Header.tsx`, `CardFilters.tsx`, and `CardItem.tsx` — all replaced with Financial Luminary CSS custom property references (`var(--primary)`, `var(--surface-container)`, `var(--on-surface)`, `var(--gradient-cta)`, etc.) or equivalent Tailwind token utility classes (`bg-surface-container`, `text-primary`, `text-on-surface-variant`).
- **DASH-001**: Dashboard hero metric updated — when the user has earned bonus points, shows total portfolio dollar value (`$X,XXX` at 2¢/point) with label "total portfolio value". Falls back to active card count for new users with no bonuses yet.

## Test plan

- [ ] Dashboard hero shows `$X,XXX total portfolio value` for users with earned bonuses
- [ ] Dashboard hero falls back to `N cards working for you` for users with 0 earned points
- [ ] Card catalog items (`CardItem`) render with surface-container background, correct accent colours — no hardcoded hex visible in devtools
- [ ] `CardFilters` filter bar background and inputs use token colours
- [ ] Header backdrop uses `surface-container-lowest` token; CTA button uses `--gradient-cta`
- [ ] WalletCard spend progress bar gradient uses `--primary-container` → `--primary`
- [ ] TypeScript compiles clean