### PR TITLE
feat(profit): ROI bento + YoY pill + flights filter chips + card ghost border

### DIFF
--- a/app/src/app/flights/page.tsx
+++ b/app/src/app/flights/page.tsx
@@ -8,13 +8,6 @@ import { AppShell } from '@/components/layout/AppShell'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { RedemptionProgress } from '@/components/flights/RedemptionProgress'
 import { AwardRouteCard, type AwardRouteRow } from '@/components/flights/AwardRouteCard'
 import { supabase } from '@/lib/supabase/client'
@@ -230,12 +223,12 @@ export default function FlightsPage() {
               Qantas Classic Rewards — Route Search
             </h2>
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-secondary)]" />
+              <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-secondary)]" />
               <Input
                 value={routeSearch}
                 onChange={(e) => handleSearch(e.target.value)}
                 placeholder="Search by IATA (SYD, LHR) or city name (Sydney, London)…"
-                className="pl-9"
+                className="rounded-full pl-10"
               />
             </div>
 
@@ -306,54 +299,62 @@ export default function FlightsPage() {
             </div>
           )}
 
-          {/* Filters + Amex toggle */}
+          {/* Filters — horizontal scrollable chip row */}
           {hasBalances && (
-            <div className="mb-4 flex flex-wrap items-center gap-3">
-              <Select
-                value={programFilter}
-                onValueChange={(v) => setProgramFilter(v as ProgramFilter)}
-              >
-                <SelectTrigger className="w-36">
-                  <SelectValue placeholder="Program" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All programs</SelectItem>
-                  <SelectItem value="qff">Qantas FF</SelectItem>
-                  <SelectItem value="velocity">Velocity</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <Select value={cabinFilter} onValueChange={(v) => setCabinFilter(v as CabinFilter)}>
-                <SelectTrigger className="w-32">
-                  <SelectValue placeholder="Cabin" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All cabins</SelectItem>
-                  <SelectItem value="economy">Economy</SelectItem>
-                  <SelectItem value="business">Business</SelectItem>
-                  <SelectItem value="first">First</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <Select value={originFilter} onValueChange={(v) => setOriginFilter(v as OriginFilter)}>
-                <SelectTrigger className="w-32">
-                  <SelectValue placeholder="Origin" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All origins</SelectItem>
-                  <SelectItem value="SYD">Sydney (SYD)</SelectItem>
-                  <SelectItem value="MEL">Melbourne (MEL)</SelectItem>
-                  <SelectItem value="BNE">Brisbane (BNE)</SelectItem>
-                </SelectContent>
-              </Select>
-
+            <div className="mb-4 space-y-2">
+              <div className="scrollbar-hide flex gap-2 overflow-x-auto pb-1">
+                {/* Program chips */}
+                {(['all', 'qff', 'velocity'] as ProgramFilter[]).map((v) => (
+                  <button
+                    key={v}
+                    onClick={() => setProgramFilter(v)}
+                    className={`shrink-0 rounded-full px-4 py-1.5 text-xs font-semibold transition-colors ${
+                      programFilter === v
+                        ? 'bg-[var(--primary)] text-[var(--on-primary)]'
+                        : 'bg-[var(--surface-container-highest)] text-[var(--on-surface-variant)] hover:bg-[var(--surface-bright)]'
+                    }`}
+                  >
+                    {v === 'all' ? 'All programs' : v === 'qff' ? 'Qantas FF' : 'Velocity'}
+                  </button>
+                ))}
+                <span className="mx-1 self-center text-white/10">|</span>
+                {/* Cabin chips */}
+                {(['all', 'economy', 'business', 'first'] as CabinFilter[]).map((v) => (
+                  <button
+                    key={v}
+                    onClick={() => setCabinFilter(v)}
+                    className={`shrink-0 rounded-full px-4 py-1.5 text-xs font-semibold capitalize transition-colors ${
+                      cabinFilter === v
+                        ? 'bg-[var(--primary)] text-[var(--on-primary)]'
+                        : 'bg-[var(--surface-container-highest)] text-[var(--on-surface-variant)] hover:bg-[var(--surface-bright)]'
+                    }`}
+                  >
+                    {v === 'all' ? 'All cabins' : v}
+                  </button>
+                ))}
+                <span className="mx-1 self-center text-white/10">|</span>
+                {/* Origin chips */}
+                {(['all', 'SYD', 'MEL', 'BNE'] as OriginFilter[]).map((v) => (
+                  <button
+                    key={v}
+                    onClick={() => setOriginFilter(v)}
+                    className={`shrink-0 rounded-full px-4 py-1.5 text-xs font-semibold transition-colors ${
+                      originFilter === v
+                        ? 'bg-[var(--primary)] text-[var(--on-primary)]'
+                        : 'bg-[var(--surface-container-highest)] text-[var(--on-surface-variant)] hover:bg-[var(--surface-bright)]'
+                    }`}
+                  >
+                    {v === 'all' ? 'All origins' : v}
+                  </button>
+                ))}
+              </div>
               {/* Amex MR toggle */}
-              <label className="ml-auto flex cursor-pointer items-center gap-2 rounded-lg border border-white/5 bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)]">
+              <label className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-white/5 bg-[var(--surface)] px-4 py-1.5 text-xs font-semibold text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)]">
                 <input
                   type="checkbox"
                   checked={includeAmexTransfers}
                   onChange={(e) => setIncludeAmexTransfers(e.target.checked)}
-                  className="h-4 w-4 accent-[var(--accent)]"
+                  className="h-3.5 w-3.5 accent-[var(--accent)]"
                 />
                 Include Amex MR transfers
               </label>

--- a/app/src/app/profit/page.tsx
+++ b/app/src/app/profit/page.tsx
@@ -330,13 +330,30 @@ export default function ProfitPage() {
               <p className="text-xs font-bold uppercase tracking-[0.3em] text-[#86948a]">
                 {fy} Net Profit
               </p>
-              <div className="mt-3 flex items-baseline gap-1">
+              <div className="mt-3 flex flex-wrap items-baseline gap-3">
                 <span
                   className="tabular-nums text-5xl font-extrabold text-[#4edea3]"
                   style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
                 >
                   {fmtAud(fyNet)}
                 </span>
+                {(() => {
+                  const prevFY = fyRows.find((r) => r.fy !== fy)
+                  if (!prevFY || prevFY.netValue === 0) return null
+                  const change = ((fyNet - prevFY.netValue) / Math.abs(prevFY.netValue)) * 100
+                  const positive = change >= 0
+                  return (
+                    <span
+                      className="rounded-full px-3 py-1 text-xs font-bold"
+                      style={{
+                        background: positive ? 'rgba(78,222,163,0.12)' : 'rgba(255,180,171,0.12)',
+                        color: positive ? '#4edea3' : '#ffb4ab',
+                      }}
+                    >
+                      {positive ? '+' : ''}{Math.round(change)}% vs last FY
+                    </span>
+                  )
+                })()}
               </div>
               <p className="mt-1 text-sm text-[#bbcabf]">This financial year</p>
 
@@ -393,6 +410,99 @@ export default function ProfitPage() {
                       </BarChart>
                     </ResponsiveContainer>
                   </div>
+                </div>
+              </div>
+            )}
+
+            {/* ── Insight bento ──────────────────────────────────────── */}
+            {fyCards.length > 0 && (() => {
+              const topCard = [...fyCards].sort((a, b) => (b.bonusAud / Math.max(b.fee, 1)) - (a.bonusAud / Math.max(a.fee, 1)))[0]
+              const potentialSavings = fyCards.filter(c => c.fee > 0 && c.bonusAud / c.fee < 1).reduce((s, c) => s + c.fee - c.bonusAud, 0)
+              const avgRoi = fyCards.length > 0
+                ? fyCards.reduce((s, c) => s + c.bonusAud / Math.max(c.fee, 1), 0) / fyCards.length
+                : 0
+
+              return (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                  <div className="glass-panel rounded-2xl p-5">
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">Potential Savings</p>
+                    <p className="mt-2 tabular-nums text-2xl font-extrabold text-[#ffb4ab]" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+                      {potentialSavings > 0 ? fmtAud(potentialSavings) : '—'}
+                    </p>
+                    <p className="mt-1 text-xs text-[#bbcabf]">fees exceeding bonus value this FY</p>
+                  </div>
+                  <div className="glass-panel rounded-2xl p-5">
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">Next ROI Peak</p>
+                    <p className="mt-2 tabular-nums text-2xl font-extrabold text-[#4edea3]" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+                      {topCard ? `${(topCard.bonusAud / Math.max(topCard.fee, 1)).toFixed(1)}x` : '—'}
+                    </p>
+                    <p className="mt-1 text-xs text-[#bbcabf]">{topCard ? `${topCard.bank} ${topCard.name}` : 'no data'}</p>
+                  </div>
+                  <div className="glass-panel rounded-2xl p-5">
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">Wallet Health</p>
+                    <p className="mt-2 tabular-nums text-2xl font-extrabold text-[#4edea3]" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+                      {avgRoi > 0 ? `${avgRoi.toFixed(1)}x` : '—'}
+                    </p>
+                    <p className="mt-1 text-xs text-[#bbcabf]">avg ROI across {fyCards.length} card{fyCards.length !== 1 ? 's' : ''} this FY</p>
+                  </div>
+                </div>
+              )
+            })()}
+
+            {/* ── High Velocity Assets ────────────────────────────────── */}
+            {fyCards.filter(c => c.fee > 0 && c.bonusAud / c.fee >= 5).length > 0 && (
+              <div className="rounded-2xl bg-[#1b1f2c] p-6" style={{ border: '1px solid rgba(78,222,163,0.1)' }}>
+                <p className="mb-4 text-sm font-bold text-white" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+                  ⚡ High Velocity Assets
+                </p>
+                <div className="space-y-3">
+                  {[...fyCards]
+                    .filter(c => c.fee > 0 && c.bonusAud / c.fee >= 5)
+                    .sort((a, b) => b.bonusAud / b.fee - a.bonusAud / a.fee)
+                    .map(c => {
+                      const roi = c.bonusAud / c.fee
+                      return (
+                        <div key={c.id} className="flex items-center justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-white">{c.bank} {c.name}</p>
+                            <p className="text-xs text-[#86948a]">{fmtAud(c.bonusAud)} bonus · {fmtAud(c.fee)} fee</p>
+                          </div>
+                          <span className="rounded-full bg-[#4edea3]/10 px-3 py-1 text-sm font-bold text-[#4edea3]">
+                            {roi.toFixed(1)}x
+                          </span>
+                        </div>
+                      )
+                    })
+                  }
+                </div>
+              </div>
+            )}
+
+            {/* ── Holding Strategy ────────────────────────────────────── */}
+            {fyCards.filter(c => c.fee > 0 && c.bonusAud / c.fee < 2).length > 0 && (
+              <div className="rounded-2xl bg-[#1b1f2c] p-6" style={{ border: '1px solid rgba(255,180,171,0.08)' }}>
+                <p className="mb-4 text-sm font-bold text-white" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+                  ◎ Holding Strategy
+                </p>
+                <div className="space-y-3">
+                  {[...fyCards]
+                    .filter(c => c.fee > 0 && c.bonusAud / c.fee < 2)
+                    .sort((a, b) => a.bonusAud / a.fee - b.bonusAud / b.fee)
+                    .map(c => {
+                      const roi = c.bonusAud / c.fee
+                      return (
+                        <div key={c.id} className="flex items-center justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-white">{c.bank} {c.name}</p>
+                            <p className="text-xs text-[#86948a]">{fmtAud(c.bonusAud)} bonus · {fmtAud(c.fee)} fee</p>
+                          </div>
+                          <span className="rounded-full bg-[#ffb4ab]/10 px-3 py-1 text-sm font-bold text-[#ffb4ab]">
+                            {roi.toFixed(1)}x
+                          </span>
+                        </div>
+                      )
+                    })
+                  }
                 </div>
               </div>
             )}

--- a/app/src/components/ui/card.tsx
+++ b/app/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-white/5 py-6 shadow-sm",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- **PROFIT-002**: Three new sections on `/profit` — insight bento row (Potential Savings / Next ROI Peak / Wallet Health) computed from current-FY data; YoY percentage pill adjacent to hero metric; High Velocity Assets list (ROI ≥ 5x); Holding Strategy list (ROI < 2x) — all rendered with Financial Luminary glass-panel / tonal styling.
- **FLIGHTS-001 (remaining)**: Search input upgraded to `rounded-full`; Select dropdowns replaced with horizontal scrollable filter chip row (program / cabin / origin) with active `bg-primary text-on-primary` fill; Amex toggle converted to pill; unused Select imports removed.
- **COMP-002**: `card.tsx` base border changed from bare `border` (opaque `--border` variable) to `border-white/5` — ghost border at 5% opacity, compliant with the No-Line Rule.

## Test plan

- [ ] `/profit` with ≥1 earned card shows insight bento (3 glass-panel stat cards)
- [ ] YoY pill appears when multiple financial years of data exist; hidden when only one FY
- [ ] High Velocity Assets section visible for cards with ROI ≥ 5x; absent otherwise
- [ ] Holding Strategy section visible for cards with ROI < 2x; absent otherwise
- [ ] `/flights` filter row is horizontal scrollable chips — active chip fills green
- [ ] Search input is `rounded-full` with icon correctly aligned
- [ ] shadcn `Card` components across app show ghost border only (no hard line)
- [ ] TypeScript compiles clean