### PR TITLE
feat(spending): mobile semicircle spend arc (MOBILE-003)

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -295,6 +295,11 @@
 .premium-glow {
   box-shadow: 0 0 20px rgba(78, 222, 163, 0.15), inset 0 0 10px rgba(78, 222, 163, 0.05);
 }
+.arc-hero-bg {
+  border-bottom-left-radius: 4rem;
+  border-bottom-right-radius: 4rem;
+  background: var(--surface-container);
+}
 
 /* ─── Page view transitions (progressive enhancement) ─── */
 @supports (view-transition-name: none) {

--- a/app/src/app/spending/page.tsx
+++ b/app/src/app/spending/page.tsx
@@ -144,6 +144,62 @@ function SpendArc({ spent, target }: { spent: number; target: number }) {
   )
 }
 
+function MobileSpendArc({ spent, target }: { spent: number; target: number }) {
+  const pct = target > 0 ? Math.min(spent / target, 1) : 0
+  const TOTAL_LEN = Math.PI * 80 // semicircle path length ≈ 251.3
+  const filled = TOTAL_LEN * pct
+  return (
+    <div className="arc-hero-bg -mx-4 px-4 pb-8 pt-4">
+      <svg width="100%" viewBox="0 0 200 100" style={{ overflow: "visible" }}>
+        {/* Track */}
+        <path
+          d="M 20 90 A 80 80 0 0 1 180 90"
+          fill="none"
+          stroke="rgba(255,255,255,0.1)"
+          strokeWidth={10}
+          strokeLinecap="round"
+        />
+        {/* Fill */}
+        <path
+          d="M 20 90 A 80 80 0 0 1 180 90"
+          fill="none"
+          stroke="#4edea3"
+          strokeWidth={10}
+          strokeLinecap="round"
+          strokeDasharray={`${filled} ${TOTAL_LEN - filled}`}
+          style={{
+            transition: "stroke-dasharray 600ms ease-out",
+            filter: "drop-shadow(0 0 8px rgba(78,222,163,0.4))",
+          }}
+        />
+        {/* Amount */}
+        <text
+          x="100"
+          y="62"
+          textAnchor="middle"
+          fill="white"
+          fontSize="20"
+          fontWeight="bold"
+          fontFamily="'Plus Jakarta Sans', sans-serif"
+        >
+          {formatCurrencyCompact(spent)}
+        </text>
+        {/* Label */}
+        <text
+          x="100"
+          y="78"
+          textAnchor="middle"
+          fill="rgba(255,255,255,0.4)"
+          fontSize="9"
+          fontFamily="Inter, sans-serif"
+        >
+          of {formatCurrencyCompact(target)}
+        </text>
+      </svg>
+    </div>
+  )
+}
+
 function formatCurrencyCompact(amount: number): string {
   if (amount >= 1000) return `$${(amount / 1000).toFixed(1)}k`
   return `$${Math.round(amount)}`
@@ -413,8 +469,13 @@ export default function SpendingTrackerPage() {
                   )
                 })()}
 
+                {/* Mobile arc (semicircle hero) — hidden on desktop */}
+                <div className="md:hidden">
+                  <MobileSpendArc spent={activeCard.current_spend} target={activeCard.spend_target} />
+                </div>
+
                 {/* Arc + stats */}
-                <div className="flex flex-col gap-5 rounded-b-[4rem] md:flex-row md:items-center">
+                <div className="hidden gap-5 rounded-b-[4rem] md:flex md:flex-row md:items-center">
                   {/* Arc — 60% width */}
                   <div className="flex flex-[3] items-center justify-center py-4">
                     <SpendArc spent={activeCard.current_spend} target={activeCard.spend_target} />


### PR DESCRIPTION
## Summary
- Add `MobileSpendArc` component — SVG semicircle path `M 20 90 A 80 80 0 0 1 180 90` with animated `stroke-dasharray` fill and glow effect
- Add `.arc-hero-bg` CSS utility: pill-shaped bottom radius (`4rem`) + `surface-container` background for the mobile arc hero section
- Responsive wiring: `md:hidden` for mobile arc, `hidden md:flex` for the existing desktop 240° arc + stats panel

## Test plan
- [ ] Mobile viewport (< 768px): semicircle arc renders with spend amount centred, no desktop arc visible
- [ ] Desktop viewport (≥ 768px): original 240° arc + glass stats panel renders, no mobile arc visible
- [ ] Arc fill animates on load and updates on card switch
- [ ] Arc section has rounded bottom corners on mobile
- [ ] `npx tsc --noEmit` passes clean