### PR TITLE
feat(dashboard): hover border glow on bonus tracker cards (ANIM-001)

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -283,7 +283,7 @@ export default function DashboardPage() {
                   ? Math.max(0, Math.ceil((new Date(card.bonus_spend_deadline).getTime() - Date.now()) / 86400000))
                   : null
                 return (
-                  <div key={card.id} className="glass-panel rounded-2xl p-5">
+                  <div key={card.id} className="glass-panel rounded-2xl p-5 transition-colors duration-200 hover:border-primary/30">
                     <div className="flex items-start justify-between gap-2">
                       <div>
                         <p className="text-xs font-bold text-on-surface">{card.bank} {card.name}</p>


### PR DESCRIPTION
## Summary
- Add `hover:border-primary/30 transition-colors duration-200` to bonus tracker bento cards, matching design spec ghost-primary border on hover

## Notes
- Confirmed `button.tsx` already has `active:scale-95` and `rounded-full` (ANIM-002 / BUTTON-001 already in place)
- `WalletCard` hover already at `group-hover:-translate-y-2` (no change needed)

## Test plan
- [ ] Hover over a bonus tracker card → border transitions from 5% white ghost to 30% primary green
- [ ] Transition is smooth (~200ms)
- [ ] No layout shift on hover (border already present from `.glass-panel`)