### PR TITLE
refactor(ui): extract shared design-system components (COMP-001)

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -11,6 +11,9 @@ import { ProGate } from "@/components/ui/ProGate"
 import { WalletCard } from "@/components/ui/WalletCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { StatCard } from "@/components/ui/stat-card"
+import { ActivityItem } from "@/components/ui/activity-item"
+import { ProgressBar } from "@/components/ui/progress-bar"
 import { EditCardModal } from "@/components/cards/EditCardModal"
 import { RecommendationCard } from "@/components/dashboard/RecommendationCard"
 import { DailyInsights } from "@/components/dashboard/DailyInsights"
@@ -261,10 +264,7 @@ export default function DashboardPage() {
             { label: "Cards Active", value: stats.active.toString() },
             { label: "Bonus Ready", value: stats.bonusReady.toString() },
           ].map(({ label, value }) => (
-            <div key={label} className="rounded-2xl bg-surface-container p-4">
-              <p className="text-xs text-on-surface-variant">{label}</p>
-              <p className="mt-1 font-mono tabular-nums text-xl text-primary">{value}</p>
-            </div>
+            <StatCard key={label} label={label} value={value} accent />
           ))}
         </div>
 
@@ -302,15 +302,7 @@ export default function DashboardPage() {
                         <span>${Math.round(card.current_spend ?? 0).toLocaleString()} spent</span>
                         <span>{pct}%</span>
                       </div>
-                      <div className="h-1.5 overflow-hidden rounded-full bg-surface-container-highest">
-                        <div
-                          className="h-full rounded-full transition-all duration-700"
-                          style={{
-                            width: `${pct}%`,
-                            background: "linear-gradient(90deg, var(--primary-container) 0%, var(--primary) 100%)",
-                          }}
-                        />
-                      </div>
+                      <ProgressBar value={pct} />
                       <p className="mt-1 text-[10px] text-on-surface-variant">
                         of ${card.spendTarget.toLocaleString()} target
                       </p>
@@ -420,19 +412,12 @@ export default function DashboardPage() {
                   ? new Date(card.bonus_earned_at).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })
                   : null
                 return (
-                  <div key={card.id} className="flex items-center justify-between px-5 py-4">
-                    <div>
-                      <p className="text-sm font-semibold text-on-surface">{card.bank} {card.name}</p>
-                      {earnedDate && (
-                        <p className="text-[10px] text-on-surface-variant">Earned {earnedDate}</p>
-                      )}
-                    </div>
-                    {card.bonusPoints > 0 && (
-                      <span className="tabular-nums text-sm font-bold text-primary">
-                        +{card.bonusPoints.toLocaleString()} pts
-                      </span>
-                    )}
-                  </div>
+                  <ActivityItem
+                    key={card.id}
+                    primary={`${card.bank} ${card.name}`}
+                    secondary={earnedDate ? `Earned ${earnedDate}` : undefined}
+                    value={card.bonusPoints > 0 ? `+${card.bonusPoints.toLocaleString()} pts` : undefined}
+                  />
                 )
               })}
             </div>

--- a/app/src/app/profit/page.tsx
+++ b/app/src/app/profit/page.tsx
@@ -14,6 +14,9 @@ import {
 import { AppShell } from "@/components/layout/AppShell"
 import { ProGate } from "@/components/ui/ProGate"
 import { Button } from "@/components/ui/button"
+import { StatCard } from "@/components/ui/stat-card"
+import { ActivityItem } from "@/components/ui/activity-item"
+import { StatusBadge } from "@/components/ui/status-badge"
 import { supabase } from "@/lib/supabase/client"
 import { getPointValue, getFinancialYear } from "@/lib/pointValuations"
 import { CardBreakdown, type ProfitCard } from "@/components/profit/CardBreakdown"
@@ -424,27 +427,26 @@ export default function ProfitPage() {
 
               return (
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                  <div className="glass-panel rounded-2xl p-5">
-                    <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">Potential Savings</p>
-                    <p className="mt-2 tabular-nums text-2xl font-extrabold text-[#ffb4ab]" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                      {potentialSavings > 0 ? fmtAud(potentialSavings) : '—'}
-                    </p>
-                    <p className="mt-1 text-xs text-[#bbcabf]">fees exceeding bonus value this FY</p>
-                  </div>
-                  <div className="glass-panel rounded-2xl p-5">
-                    <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">Next ROI Peak</p>
-                    <p className="mt-2 tabular-nums text-2xl font-extrabold text-[#4edea3]" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                      {topCard ? `${(topCard.bonusAud / Math.max(topCard.fee, 1)).toFixed(1)}x` : '—'}
-                    </p>
-                    <p className="mt-1 text-xs text-[#bbcabf]">{topCard ? `${topCard.bank} ${topCard.name}` : 'no data'}</p>
-                  </div>
-                  <div className="glass-panel rounded-2xl p-5">
-                    <p className="text-[10px] font-bold uppercase tracking-widest text-[#86948a]">Wallet Health</p>
-                    <p className="mt-2 tabular-nums text-2xl font-extrabold text-[#4edea3]" style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                      {avgRoi > 0 ? `${avgRoi.toFixed(1)}x` : '—'}
-                    </p>
-                    <p className="mt-1 text-xs text-[#bbcabf]">avg ROI across {fyCards.length} card{fyCards.length !== 1 ? 's' : ''} this FY</p>
-                  </div>
+                  <StatCard
+                    label="Potential Savings"
+                    value={potentialSavings > 0 ? fmtAud(potentialSavings) : '—'}
+                    sub="fees exceeding bonus value this FY"
+                    className="p-5"
+                  />
+                  <StatCard
+                    label="Next ROI Peak"
+                    value={topCard ? `${(topCard.bonusAud / Math.max(topCard.fee, 1)).toFixed(1)}x` : '—'}
+                    sub={topCard ? `${topCard.bank} ${topCard.name}` : 'no data'}
+                    accent
+                    className="p-5"
+                  />
+                  <StatCard
+                    label="Wallet Health"
+                    value={avgRoi > 0 ? `${avgRoi.toFixed(1)}x` : '—'}
+                    sub={`avg ROI across ${fyCards.length} card${fyCards.length !== 1 ? 's' : ''} this FY`}
+                    accent
+                    className="p-5"
+                  />
                 </div>
               )
             })()}
@@ -462,15 +464,13 @@ export default function ProfitPage() {
                     .map(c => {
                       const roi = c.bonusAud / c.fee
                       return (
-                        <div key={c.id} className="flex items-center justify-between">
-                          <div>
-                            <p className="text-sm font-semibold text-white">{c.bank} {c.name}</p>
-                            <p className="text-xs text-[#86948a]">{fmtAud(c.bonusAud)} bonus · {fmtAud(c.fee)} fee</p>
-                          </div>
-                          <span className="rounded-full bg-[#4edea3]/10 px-3 py-1 text-sm font-bold text-[#4edea3]">
-                            {roi.toFixed(1)}x
-                          </span>
-                        </div>
+                        <ActivityItem
+                          key={c.id}
+                          primary={`${c.bank} ${c.name}`}
+                          secondary={`${fmtAud(c.bonusAud)} bonus · ${fmtAud(c.fee)} fee`}
+                          value={<StatusBadge variant="primary">{roi.toFixed(1)}x</StatusBadge>}
+                          className="px-0 py-0"
+                        />
                       )
                     })
                   }
@@ -491,15 +491,13 @@ export default function ProfitPage() {
                     .map(c => {
                       const roi = c.bonusAud / c.fee
                       return (
-                        <div key={c.id} className="flex items-center justify-between">
-                          <div>
-                            <p className="text-sm font-semibold text-white">{c.bank} {c.name}</p>
-                            <p className="text-xs text-[#86948a]">{fmtAud(c.bonusAud)} bonus · {fmtAud(c.fee)} fee</p>
-                          </div>
-                          <span className="rounded-full bg-[#ffb4ab]/10 px-3 py-1 text-sm font-bold text-[#ffb4ab]">
-                            {roi.toFixed(1)}x
-                          </span>
-                        </div>
+                        <ActivityItem
+                          key={c.id}
+                          primary={`${c.bank} ${c.name}`}
+                          secondary={`${fmtAud(c.bonusAud)} bonus · ${fmtAud(c.fee)} fee`}
+                          value={<StatusBadge variant="danger">{roi.toFixed(1)}x</StatusBadge>}
+                          className="px-0 py-0"
+                        />
                       )
                     })
                   }

--- a/app/src/app/spending/page.tsx
+++ b/app/src/app/spending/page.tsx
@@ -6,6 +6,7 @@ import { AppShell } from "@/components/layout/AppShell"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { StatCard } from "@/components/ui/stat-card"
 import {
   Dialog,
   DialogContent,
@@ -446,24 +447,14 @@ export default function SpendingTrackerPage() {
                   return (
                     <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
                       {stats.map((s) => (
-                        <div key={s.label} className="glass-panel rounded-2xl p-4">
-                          <div className="flex items-center justify-between">
-                            <p className="text-[10px] font-bold uppercase tracking-widest text-[#bbcabf]">
-                              {s.label}
-                            </p>
-                            <span className="text-[#4edea3]/40 text-sm">{s.icon}</span>
-                          </div>
-                          <p
-                            className="mt-2 text-2xl font-black tabular-nums"
-                            style={{
-                              fontFamily: "'Plus Jakarta Sans', sans-serif",
-                              color: s.accent ? "#4edea3" : "#dfe2f3",
-                            }}
-                          >
-                            {s.value}
-                          </p>
-                          <p className="mt-0.5 text-[11px] text-[#bbcabf]">{s.sub}</p>
-                        </div>
+                        <StatCard
+                          key={s.label}
+                          label={s.label}
+                          value={s.value}
+                          sub={s.sub}
+                          icon={s.icon}
+                          accent={s.accent}
+                        />
                       ))}
                     </div>
                   )

--- a/app/src/components/ui/activity-item.tsx
+++ b/app/src/components/ui/activity-item.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface ActivityItemProps {
+  primary: string
+  secondary?: string
+  value?: React.ReactNode
+  className?: string
+}
+
+export function ActivityItem({ primary, secondary, value, className }: ActivityItemProps) {
+  return (
+    <div className={cn("flex items-center justify-between px-5 py-4", className)}>
+      <div>
+        <p className="text-sm font-semibold text-on-surface">{primary}</p>
+        {secondary && (
+          <p className="text-[10px] text-on-surface-variant">{secondary}</p>
+        )}
+      </div>
+      {value !== undefined && (
+        <span className="tabular-nums text-sm font-bold text-primary">{value}</span>
+      )}
+    </div>
+  )
+}

--- a/app/src/components/ui/progress-bar.tsx
+++ b/app/src/components/ui/progress-bar.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils"
+
+interface ProgressBarProps {
+  /** 0–100 */
+  value: number
+  height?: "sm" | "md"
+  className?: string
+}
+
+export function ProgressBar({ value, height = "sm", className }: ProgressBarProps) {
+  const clamped = Math.min(100, Math.max(0, value))
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-full bg-surface-container-highest",
+        height === "sm" ? "h-1.5" : "h-2",
+        className,
+      )}
+    >
+      <div
+        className="h-full rounded-full transition-all duration-700"
+        style={{
+          width: `${clamped}%`,
+          background: "linear-gradient(90deg, var(--primary-container) 0%, var(--primary) 100%)",
+        }}
+      />
+    </div>
+  )
+}

--- a/app/src/components/ui/stat-card.tsx
+++ b/app/src/components/ui/stat-card.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface StatCardProps {
+  label: string
+  value: string
+  sub?: string
+  icon?: React.ReactNode
+  accent?: boolean
+  className?: string
+}
+
+export function StatCard({ label, value, sub, icon, accent = false, className }: StatCardProps) {
+  return (
+    <div className={cn("glass-panel rounded-2xl p-4", className)}>
+      <div className="flex items-center justify-between">
+        <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+          {label}
+        </p>
+        {icon && <span className="text-sm text-primary/40">{icon}</span>}
+      </div>
+      <p
+        className={cn(
+          "mt-2 text-2xl font-black tabular-nums",
+          accent ? "text-primary" : "text-on-surface",
+        )}
+        style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+      >
+        {value}
+      </p>
+      {sub && <p className="mt-0.5 text-[11px] text-on-surface-variant">{sub}</p>}
+    </div>
+  )
+}

--- a/app/src/components/ui/status-badge.tsx
+++ b/app/src/components/ui/status-badge.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+type BadgeVariant = "primary" | "warning" | "danger" | "neutral"
+
+const variantClasses: Record<BadgeVariant, string> = {
+  primary: "bg-primary/10 text-primary",
+  warning: "bg-amber-400/10 text-amber-400",
+  danger: "bg-[#ffb4ab]/10 text-[#ffb4ab]",
+  neutral: "bg-on-surface/10 text-on-surface-variant",
+}
+
+interface StatusBadgeProps {
+  children: React.ReactNode
+  variant?: BadgeVariant
+  className?: string
+}
+
+export function StatusBadge({ children, variant = "primary", className }: StatusBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "rounded-full px-3 py-1 text-xs font-bold",
+        variantClasses[variant],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
- **StatCard** — `glass-panel rounded-2xl` card with label (10px uppercase tracking), large value (font-black tabular-nums), optional sub-text + icon + accent variant
- **ActivityItem** — `flex items-center justify-between` row with two-line left text and typed right slot
- **ProgressBar** — `h-1.5 overflow-hidden rounded-full` track with gradient fill + `duration-700` transition
- **StatusBadge** — `rounded-full px-3 py-1 font-bold` pill with `primary | warning | danger | neutral` variants

Wired into:
- Dashboard: stats row (4×), bonus tracker progress bar, recent bonuses feed
- Spending: 4-column stat card row
- Profit: insight bento (3×), High Velocity + Holding Strategy ROI items

## Test plan
- [ ] Dashboard stats row renders 4 StatCards with correct accent colour
- [ ] Bonus tracker progress bar fills correctly
- [ ] Recent bonuses ActivityItem rows render primary/secondary/value
- [ ] Spending 4-column stat cards render with icons + accent states
- [ ] Profit insight bento renders 3 StatCards
- [ ] High Velocity items show green StatusBadge; Holding Strategy shows red
- [ ] `npx tsc --noEmit` passes clean