### PR TITLE
fix(layout): sidebar offset + overflow + mobile nav height + carousel width

### DIFF
--- a/app/src/app/cards/page.tsx
+++ b/app/src/app/cards/page.tsx
@@ -161,7 +161,7 @@ export default function CardsPage() {
             <div className="md:hidden">
               <div className="scrollbar-hide flex snap-x snap-mandatory gap-4 overflow-x-auto pb-2">
                 {filtered.map((card) => (
-                  <div key={card.id} className="w-72 shrink-0 snap-start">
+                  <div key={card.id} className="min-w-[310px] shrink-0 snap-start">
                     <CatalogCardThumb card={card} />
                     <p className="mt-2 truncate text-sm font-medium text-on-surface">{card.name}</p>
                     <p className="text-xs text-on-surface-variant">{card.bank}</p>

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -283,6 +283,13 @@
   }
 }
 
+/* ─── Sidebar layout offset (guaranteed, supplements md:pl-64) ─── */
+@media (min-width: 768px) {
+  .md\:pl-64 {
+    padding-left: 16rem !important; /* 256px = w-64 sidebar */
+  }
+}
+
 /* ─── Glassmorphism utilities ─── */
 .glass-panel {
   background: rgba(255, 255, 255, 0.03);

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -53,7 +53,7 @@ export function AppShell({ children }: AppShellProps) {
   const isActive = (href: string) => pathname.startsWith(href)
 
   return (
-    <div className="min-h-screen" style={{ background: "var(--surface)" }}>
+    <div className="min-h-screen overflow-x-hidden" style={{ background: "var(--surface)" }}>
       {/* ── Desktop fixed sidebar ── */}
       <aside
         className="hidden md:flex fixed left-0 top-0 h-screen w-64 flex-col z-30"
@@ -173,8 +173,8 @@ export function AppShell({ children }: AppShellProps) {
       </header>
 
       {/* ── Page content ── */}
-      <div className="md:pl-64 pb-24 md:pb-6">
-        <main className="min-w-0">{children}</main>
+      <div className="md:pl-64 pb-24 md:pb-6 min-w-0">
+        <main className="min-w-0 overflow-x-hidden">{children}</main>
       </div>
 
       {/* ── Mobile bottom nav ── */}
@@ -187,7 +187,7 @@ export function AppShell({ children }: AppShellProps) {
           boxShadow: "0 -8px 32px rgba(0,0,0,0.5)",
         }}
       >
-        <div className="grid grid-cols-5 pb-safe">
+        <div className="grid grid-cols-5 h-20 pb-safe">
           {navItems.map(({ href, label, icon: Icon }) => {
             const active = isActive(href)
             return (


### PR DESCRIPTION
## Summary
- **P1**: Add `overflow-x-hidden` to AppShell root and `<main>` — eliminates horizontal bleed on landing + dashboard (fixed width blobs/hero sections)
- **P1**: Guarantee `md:pl-64` sidebar offset via explicit `@media (min-width: 768px)` rule in `globals.css` — content now correctly offsets 256px on desktop
- **P2**: Profit chart `overflow-x-auto` + `minWidth: 480` already present from prior PR — MOB-004 resolved
- **P3**: Mobile bottom nav height `h-20` (80px spec) — was collapsing to 52px
- **P3**: Cards carousel snap items `min-w-[310px]` — was `w-72` (288px)