### PR TITLE
fix(tokens): replace hard-coded hex with CSS var token classes + ghost borders

### DIFF
--- a/app/src/app/calendar/page.tsx
+++ b/app/src/app/calendar/page.tsx
@@ -207,7 +207,7 @@ export default function CalendarPage() {
         </div>
 
         {bankTimelines.length === 0 ? (
-          <Card className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm">
+          <Card className="border border-white/5 bg-[var(--surface)] shadow-sm">
             <CardContent className="py-8 text-center">
               <CalendarDays className="mx-auto mb-3 h-8 w-8 text-[var(--text-secondary)]/40" />
               <p className="font-medium text-[var(--text-primary)]">No card history yet</p>
@@ -225,7 +225,7 @@ export default function CalendarPage() {
               return (
                 <Card
                   key={timeline.bank}
-                  className="border border-[var(--border-default)] bg-[var(--surface)] shadow-sm"
+                  className="border border-white/5 bg-[var(--surface)] shadow-sm"
                   data-bank-timeline={timeline.bank}
                 >
                   <CardContent className="p-4">
@@ -262,7 +262,7 @@ export default function CalendarPage() {
                       {timeline.cards.map(({ card, stages }) => (
                         <div
                           key={card.id}
-                          className="rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-2"
+                          className="rounded-lg border border-white/5 bg-[var(--surface-muted)] px-3 py-2"
                         >
                           <p className="mb-1.5 text-xs font-semibold text-[var(--text-primary)]">
                             {card.card?.name || card.name || "Unknown card"}

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -186,13 +186,13 @@ export default function DashboardPage() {
     return (
       <AppShell>
         <div className="space-y-5">
-          <div className="h-14 animate-pulse rounded-xl bg-[#1b1f2c]" />
+          <div className="h-14 animate-pulse rounded-xl bg-surface-container" />
           <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
             {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="h-20 animate-pulse rounded-xl bg-[#1b1f2c]" />
+              <div key={i} className="h-20 animate-pulse rounded-xl bg-surface-container" />
             ))}
           </div>
-          <div className="h-48 animate-pulse rounded-xl bg-[#1b1f2c]" />
+          <div className="h-48 animate-pulse rounded-xl bg-surface-container" />
         </div>
       </AppShell>
     )
@@ -427,7 +427,7 @@ export default function DashboardPage() {
         {/* Top recommendation */}
         {topRecommendation && (
           <div>
-            <p className="mb-2 text-sm font-medium text-slate-400">Top opportunity</p>
+            <p className="mb-2 text-sm font-medium text-on-surface-variant">Top opportunity</p>
             <RecommendationCard recommendation={topRecommendation} variant="hero" />
           </div>
         )}
@@ -435,24 +435,24 @@ export default function DashboardPage() {
         {/* Projection preview */}
         {projection && (
           <ProGate feature="goal projections & timeline">
-            <Card className="border-[#4edea3]/20 bg-[#1b1f2c] shadow-sm">
+            <Card className="border-primary/20 bg-surface-container shadow-sm">
               <CardContent className="pt-5">
                 <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                   <div className="space-y-1.5">
                     <div className="flex items-center gap-2">
-                      <TrendingUp className="h-4 w-4 text-[#4edea3]" />
-                      <p className="text-sm font-medium text-slate-400">Goal projection</p>
+                      <TrendingUp className="h-4 w-4 text-primary" />
+                      <p className="text-sm font-medium text-on-surface-variant">Goal projection</p>
                     </div>
-                    <p className="text-xl font-semibold text-[#dfe2f3]">
+                    <p className="text-xl font-semibold text-on-surface">
                       {projection.goal.label} in{" "}
-                      <span className="text-[#4edea3]">{projection.path.timeToGoal} months</span>
+                      <span className="text-primary">{projection.path.timeToGoal} months</span>
                     </p>
-                    <div className="flex items-center gap-3 text-xs text-slate-400">
+                    <div className="flex items-center gap-3 text-xs text-on-surface-variant">
                       <span>{projection.path.totalPoints.toLocaleString()} pts</span>
                       <span>·</span>
                       <span>${projection.path.totalCost} fees</span>
                       <span>·</span>
-                      <span className="text-[#4edea3]">
+                      <span className="text-primary">
                         ${projection.path.netValue.toFixed(0)} net value
                       </span>
                     </div>
@@ -461,7 +461,7 @@ export default function DashboardPage() {
                     <Button
                       variant="outline"
                       size="sm"
-                      className="rounded-full border-[#313442] text-[#dfe2f3] hover:bg-[#313442]"
+                      className="rounded-full border-surface-container-highest text-on-surface hover:bg-surface-container-highest"
                     >
                       View all goals
                     </Button>
@@ -476,7 +476,7 @@ export default function DashboardPage() {
         {userId && (
           <ProGate feature="daily insights & deals">
             <div>
-              <p className="mb-2 text-sm font-medium text-slate-400">Today&apos;s activity</p>
+              <p className="mb-2 text-sm font-medium text-on-surface-variant">Today&apos;s activity</p>
               <DailyInsights userId={userId} />
             </div>
           </ProGate>

--- a/app/src/app/spending/page.tsx
+++ b/app/src/app/spending/page.tsx
@@ -219,20 +219,20 @@ function formatDate(dateStr: string): string {
 }
 
 function getPaceStatus(card: UserCard): { label: string; color: string } {
-  if (!card.spend_deadline || !card.spend_target) return { label: "On Track", color: "text-[#4edea3]" }
+  if (!card.spend_deadline || !card.spend_target) return { label: "On Track", color: "text-primary" }
 
   const remaining = card.spend_target - card.current_spend
-  if (remaining <= 0) return { label: "Bonus Earned", color: "text-[#4edea3]" }
+  if (remaining <= 0) return { label: "Bonus Earned", color: "text-primary" }
 
   const daysLeft = Math.ceil(
     (new Date(card.spend_deadline).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
   )
-  if (daysLeft <= 0) return { label: "Will Miss Bonus", color: "text-[#ffb4ab]" }
+  if (daysLeft <= 0) return { label: "Will Miss Bonus", color: "text-destructive" }
 
   const dailyNeeded = remaining / daysLeft
-  if (dailyNeeded > 100) return { label: "Will Miss Bonus", color: "text-[#ffb4ab]" }
+  if (dailyNeeded > 100) return { label: "Will Miss Bonus", color: "text-destructive" }
   if (dailyNeeded > 50) return { label: "Behind Pace", color: "text-amber-400" }
-  return { label: "On Track", color: "text-[#4edea3]" }
+  return { label: "On Track", color: "text-primary" }
 }
 
 export default function SpendingTrackerPage() {
@@ -331,10 +331,10 @@ export default function SpendingTrackerPage() {
     return (
       <AppShell>
         <div className="space-y-5">
-          <div className="h-14 animate-pulse rounded-xl bg-[#1b1f2c]" />
-          <div className="h-64 animate-pulse rounded-2xl bg-[#1b1f2c]" />
+          <div className="h-14 animate-pulse rounded-xl bg-surface-container" />
+          <div className="h-64 animate-pulse rounded-2xl bg-surface-container" />
           {[1, 2].map((i) => (
-            <div key={i} className="h-20 animate-pulse rounded-xl bg-[#1b1f2c]" />
+            <div key={i} className="h-20 animate-pulse rounded-xl bg-surface-container" />
           ))}
         </div>
       </AppShell>
@@ -349,9 +349,9 @@ export default function SpendingTrackerPage() {
       <div className="space-y-6 pb-10">
         {/* Page header */}
         <div>
-          <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#4edea3]">Spending</p>
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary">Spending</p>
           <h1
-            className="mt-1 bg-gradient-to-br from-[#4edea3] to-[#10b981] bg-clip-text text-2xl font-black text-transparent"
+            className="mt-1 bg-gradient-to-br from-primary to-primary-container bg-clip-text text-2xl font-black text-transparent"
             style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
           >
             Spend Tracker
@@ -366,11 +366,11 @@ export default function SpendingTrackerPage() {
             >
               No active cards
             </p>
-            <p className="text-sm text-[#bbcabf]">
+            <p className="text-sm text-on-surface-variant">
               Add cards with spending requirements to track your progress.
             </p>
             <Button
-              className="rounded-full font-bold text-[#003824]"
+              className="rounded-full font-bold text-on-primary"
               style={{ background: "var(--gradient-cta)" }}
               onClick={() => (window.location.href = "/cards")}
             >
@@ -388,7 +388,7 @@ export default function SpendingTrackerPage() {
                 <select
                   value={selectedCardId ?? ""}
                   onChange={(e) => setSelectedCardId(e.target.value)}
-                  className="w-full rounded-xl border border-white/10 bg-[#1b1f2c] px-4 py-2.5 text-sm text-white focus:outline-none focus:ring-1 focus:ring-[#4edea3]/40"
+                  className="w-full rounded-xl border border-white/10 bg-surface-container px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-1 focus:ring-primary/40"
                 >
                   {userCards.map((c) => (
                     <option key={c.id} value={c.id}>


### PR DESCRIPTION
## Summary

- **TOKEN-002** (`dashboard/page.tsx`): Replace `#1b1f2c`, `#4edea3`, `#dfe2f3`, `#313442` with `bg-surface-container`, `text-primary`, `text-on-surface`, `text-on-surface-variant`, `border-surface-container-highest` etc.
- **TOKEN-002** (`spending/page.tsx`): Skeleton loaders, page header gradient, empty-state text/button, card selector — all now use token classes
- **NOLINEV-001** (`calendar/page.tsx`): `border-[var(--border-default)]` → `border-white/5` on Card wrappers and inner timeline rows (3 instances)

## Test plan

- [ ] Dashboard loading skeletons match surface-container bg tone
- [ ] Dashboard projection card uses emerald primary tokens (not hardcoded green)
- [ ] Spending page header gradient, selector, pace status use token classes
- [ ] Calendar page cards have ghost `border-white/5` instead of opaque border-default