### PR TITLE
fix(cards): tabular-nums on welcome bonus points (TYPO-002)

### DIFF
--- a/app/src/app/cards/page.tsx
+++ b/app/src/app/cards/page.tsx
@@ -32,7 +32,7 @@ function CatalogCardThumb({ card }: { card: CardRecord }) {
       <div className="relative z-10">
         <p className={`font-headline text-sm font-bold tracking-wide ${textColor}`}>{card.name}</p>
         {card.welcome_bonus_points ? (
-          <p className={`mt-0.5 text-[10px] ${textMuted}`}>
+          <p className={`mt-0.5 tabular-nums text-[10px] ${textMuted}`}>
             {card.welcome_bonus_points.toLocaleString()} {card.points_currency ?? "pts"}
           </p>
         ) : null}


### PR DESCRIPTION
## Summary
- Add `tabular-nums` to the welcome bonus points display on the card face in `/cards` page
- Aligns with the global `font-variant-numeric: tabular-nums` enforcement across all financial values

## Test plan
- [ ] Cards page: welcome bonus points (e.g. "80,000 pts") renders with tabular-nums alignment
- [ ] `npx tsc --noEmit` passes clean