### PR TITLE
fix(layout): resolve horizontal overflow and mobile nav height

### DIFF
--- a/app/src/app/cards/page.tsx
+++ b/app/src/app/cards/page.tsx
@@ -161,7 +161,7 @@ export default function CardsPage() {
             <div className="md:hidden">
               <div className="scrollbar-hide flex snap-x snap-mandatory gap-4 overflow-x-auto pb-2">
                 {filtered.map((card) => (
-                  <div key={card.id} className="min-w-[310px] shrink-0 snap-start">
+                  <div key={card.id} className="min-w-[310px] shrink-0 snap-start" style={{ minWidth: '310px' }}>
                     <CatalogCardThumb card={card} />
                     <p className="mt-2 truncate text-sm font-medium text-on-surface">{card.name}</p>
                     <p className="text-xs text-on-surface-variant">{card.bank}</p>

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -354,7 +354,7 @@ export default function DashboardPage() {
             <>
               {/* Stacked card visual for first 3 */}
               {cards.filter(c => c.status === "active").length >= 2 ? (
-                <div className="relative mb-6" style={{ height: 180 }}>
+                <div className="relative mb-6 overflow-x-hidden" style={{ height: 180 }}>
                   {cards
                     .filter(c => c.status === "active")
                     .slice(0, 3)

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -187,7 +187,7 @@ export function AppShell({ children }: AppShellProps) {
           boxShadow: "0 -8px 32px rgba(0,0,0,0.5)",
         }}
       >
-        <div className="grid grid-cols-5 h-20 pb-safe">
+        <div className="grid grid-cols-5 h-20 pb-safe" style={{ minHeight: 80 }}>
           {navItems.map(({ href, label, icon: Icon }) => {
             const active = isActive(href)
             return (


### PR DESCRIPTION
## Summary

- **Horizontal overflow (P1)**: Added `overflow-x-hidden` to the 3D stacked card container on `/dashboard`. The `rotate-3` CSS transform on absolutely-positioned cards was causing content to spill 19px past the 1440px desktop viewport and 6px past 390px mobile viewport.
- **Mobile nav height (P3)**: Added `style={{ minHeight: 80 }}` inline on the nav grid div in `AppShell`. The Tailwind `h-20` utility (80px) was not being applied in the production build, falling back to ~52px natural button height.
- **Cards carousel width (P3)**: Added `style={{ minWidth: '310px' }}` inline on carousel card wrappers. The `min-w-[310px]` utility was not generating in production, resulting in 288px cards instead of the spec 310px.

## Root cause

Tailwind v4 JIT is not reliably generating arbitrary-value utilities (`h-20`, `min-w-[310px]`) and responsive variants for some components in the production bundle. Inline styles guarantee correctness regardless of CSS bundle state.

## Test plan

- [ ] Desktop `/dashboard`: no horizontal scrollbar, content stays within 1440px
- [ ] Mobile `/dashboard`: no horizontal scrollbar, content within 390px
- [ ] Mobile nav: bottom nav height visually ~80px (taller than before)
- [ ] Mobile `/cards`: carousel card thumbnails are at least 310px wide