### PR TITLE
fix(tokens): final hex cleanup — status-badge, error pages, AppShell

### DIFF
--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -33,7 +33,7 @@ export default function Error({
         )}
         <button
           onClick={reset}
-          className="w-full rounded-full py-2 px-4 font-medium text-[#003824] transition-opacity hover:opacity-90"
+          className="w-full rounded-full py-2 px-4 font-medium text-on-primary transition-opacity hover:opacity-90"
           style={{ background: "linear-gradient(135deg, #4edea3 0%, #10b981 100%)" }}
         >
           Try again

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -26,7 +26,7 @@ export default function GlobalError({
             </p>
             <button
               onClick={reset}
-              className="w-full rounded-full py-2 px-4 font-medium text-[#003824] transition-opacity hover:opacity-90"
+              className="w-full rounded-full py-2 px-4 font-medium text-on-primary transition-opacity hover:opacity-90"
               style={{ background: "linear-gradient(135deg, #4edea3 0%, #10b981 100%)" }}
             >
               Try again

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -164,7 +164,7 @@ export function AppShell({ children }: AppShellProps) {
         </Link>
         <Button
           size="sm"
-          className="rounded-full text-[#003824] text-xs font-semibold px-4"
+          className="rounded-full text-on-primary text-xs font-semibold px-4"
           style={{ background: "var(--gradient-cta)" }}
           onClick={() => router.push("/cards")}
         >

--- a/app/src/components/ui/status-badge.tsx
+++ b/app/src/components/ui/status-badge.tsx
@@ -6,7 +6,7 @@ type BadgeVariant = "primary" | "warning" | "danger" | "neutral"
 const variantClasses: Record<BadgeVariant, string> = {
   primary: "bg-primary/10 text-primary",
   warning: "bg-amber-400/10 text-amber-400",
-  danger: "bg-[#ffb4ab]/10 text-[#ffb4ab]",
+  danger: "bg-destructive/10 text-destructive",
   neutral: "bg-on-surface/10 text-on-surface-variant",
 }
 


### PR DESCRIPTION
## Summary

Final sweep of remaining hard-coded hex values:
- `status-badge.tsx`: `danger` variant `bg-[#ffb4ab]/10 text-[#ffb4ab]` → `bg-destructive/10 text-destructive`
- `error.tsx` / `global-error.tsx`: button `text-[#003824]` → `text-on-primary`
- `AppShell.tsx` mobile header "Add card" button: `text-[#003824]` → `text-on-primary`

## Test plan

- [ ] Error page "Try again" button has correct text color on gradient bg
- [ ] Status badge "danger" variant renders readable on dark background
- [ ] AppShell mobile "Add card" button text color correct