### PR TITLE
fix(auth): port Stitch login + signup designs

### DIFF
--- a/app/src/app/(auth)/login/page.tsx
+++ b/app/src/app/(auth)/login/page.tsx
@@ -4,12 +4,8 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { toast } from "sonner"
+import { Mail, Lock, ArrowRight, Zap } from "lucide-react"
 
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { PublicHeader } from "@/components/layout/PublicHeader"
 import { supabase } from "@/lib/supabase/client"
 
 export default function LoginPage() {
@@ -38,9 +34,7 @@ export default function LoginPage() {
 
       if (error) throw error
 
-      // Keep loading state during navigation
       router.push("/dashboard")
-      // Don't set isLoading false - keep it true during redirect
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Login failed. Try again."
@@ -80,127 +74,170 @@ export default function LoginPage() {
   }
 
   return (
-      <Card className="w-full max-w-md mx-auto border border-[var(--border-default)] bg-[var(--surface)] shadow-xl">
-        <CardHeader className="space-y-3">
-          <CardTitle className="text-2xl font-semibold text-[var(--text-primary)]">
-            Log in to your account
-          </CardTitle>
-          <p className="text-sm text-[var(--text-secondary)]">Australian credit card rewards tracker</p>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <form onSubmit={handleLogin} className="space-y-4" name="login">
-            <div className="space-y-2">
-              <Label htmlFor="email" className="text-[var(--text-primary)]">
-                Email
-              </Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                autoComplete="email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                required
-                placeholder="you@example.com"
-                className="border-[var(--border-default)] bg-[var(--surface-soft)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]"
-              />
+    <>
+      {/* Ambient glow blobs */}
+      <div
+        className="pointer-events-none fixed top-[-10%] left-[-10%] w-[60%] h-[60%] z-0"
+        style={{ background: "radial-gradient(circle, rgba(78,222,163,0.15) 0%, rgba(78,222,163,0) 70%)" }}
+      />
+      <div
+        className="pointer-events-none fixed bottom-[-10%] right-[-10%] w-[60%] h-[60%] z-0"
+        style={{ background: "radial-gradient(circle, rgba(208,188,255,0.10) 0%, rgba(208,188,255,0) 70%)" }}
+      />
+
+      <div className="relative z-10 w-full max-w-md px-4">
+        {/* Glass card */}
+        <div className="glass-card rounded-2xl p-8 md:p-12 shadow-[0px_24px_48px_-12px_rgba(0,0,0,0.4)]">
+
+          {/* Brand section */}
+          <div className="mb-10 text-center">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-xl bg-surface-container-highest border border-outline-variant/15 mb-4">
+              <Zap className="h-7 w-7 text-primary fill-primary" />
             </div>
+            <h1 className="font-headline text-3xl font-extrabold tracking-tighter text-on-surface">
+              Reward Relay
+            </h1>
+            <p className="text-on-surface-variant text-sm font-medium mt-1 tracking-wide">
+              The Sovereign Ledger of Prestige
+            </p>
+          </div>
+
+          {/* Login form */}
+          <form onSubmit={handleLogin} name="login" className="space-y-6">
+            {/* Email */}
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-[var(--text-primary)]">
-                Password
-              </Label>
-              <Input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                required
-                placeholder="••••••••"
-                className="border-[var(--border-default)] bg-[var(--surface-soft)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]"
-              />
+              <label
+                htmlFor="email"
+                className="block text-[10px] uppercase tracking-[0.05em] font-bold text-on-surface-variant px-1"
+              >
+                Email Address
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-outline pointer-events-none" />
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  placeholder="name@luxury.com"
+                  className="w-full h-14 pl-12 pr-5 bg-surface-container-highest rounded-2xl border-none text-on-surface placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all font-medium"
+                />
+              </div>
             </div>
-            <Button
+
+            {/* Password */}
+            <div className="space-y-2">
+              <div className="flex justify-between items-center px-1">
+                <label
+                  htmlFor="password"
+                  className="block text-[10px] uppercase tracking-[0.05em] font-bold text-on-surface-variant"
+                >
+                  Password
+                </label>
+                <Link
+                  href="/reset-password"
+                  className="text-[10px] uppercase tracking-[0.05em] font-bold text-on-surface-variant hover:text-primary transition-colors"
+                >
+                  Forgot Password?
+                </Link>
+              </div>
+              <div className="relative">
+                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-outline pointer-events-none" />
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  placeholder="••••••••"
+                  className="w-full h-14 pl-12 pr-5 bg-surface-container-highest rounded-2xl border-none text-on-surface placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all font-medium"
+                />
+              </div>
+            </div>
+
+            {/* CTA */}
+            <button
               type="submit"
-              className="w-full"
               disabled={isLoading || !email || !password}
+              className="w-full h-14 mt-4 bg-gradient-to-br from-[#4edea3] to-[#10b981] text-[#00432c] font-headline font-extrabold rounded-full hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-lg shadow-primary/20 flex items-center justify-center gap-2 group"
             >
-              {isLoading ? "Logging in..." : "Log in"}
-            </Button>
+              {isLoading ? "Signing in…" : "Sign in"}
+              {!isLoading && (
+                <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
+              )}
+            </button>
           </form>
+
+          {/* Footer — sign up or beta request form */}
           {!showBetaForm ? (
-            <>
-              <div className="mt-4 text-center text-sm text-[var(--text-secondary)]">
+            <div className="mt-8 text-center">
+              <p className="text-on-surface-variant text-sm font-medium">
                 Don&apos;t have an account?{" "}
                 <button
                   type="button"
                   onClick={() => setShowBetaForm(true)}
-                  className="text-[var(--accent)] underline hover:text-[var(--accent-strong)] transition-colors"
+                  className="text-primary font-bold hover:underline underline-offset-4 ml-1"
                 >
-                  Request access
+                  Sign up
                 </button>
-              </div>
-              <div className="mt-2 text-center text-sm text-[var(--text-secondary)]">
-                <Link href="/reset-password" className="text-[var(--accent)] underline hover:text-[var(--accent-strong)] transition-colors">
-                  Forgot password?
-                </Link>
-              </div>
-            </>
+              </p>
+            </div>
           ) : (
-            <div className="mt-6 pt-6 border-t border-[var(--border-default)]">
+            <div className="mt-8 pt-8 border-t border-white/5 space-y-4">
+              <p className="text-xs font-bold text-on-surface-variant text-center uppercase tracking-widest mb-4">
+                Request Beta Access
+              </p>
               <form onSubmit={handleBetaRequest} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="beta-email" className="text-[var(--text-primary)]">
-                    Email
-                  </Label>
-                  <Input
-                    id="beta-email"
-                    type="email"
-                    value={betaEmail}
-                    onChange={(e) => setBetaEmail(e.target.value)}
-                    required
-                    placeholder="you@example.com"
-                    className="border-[var(--border-default)] bg-[var(--surface-soft)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="beta-name" className="text-[var(--text-primary)]">
-                    Name (optional)
-                  </Label>
-                  <Input
-                    id="beta-name"
-                    type="text"
-                    value={betaName}
-                    onChange={(e) => setBetaName(e.target.value)}
-                    placeholder="Your name"
-                    className="border-[var(--border-default)] bg-[var(--surface-soft)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]"
-                  />
-                </div>
-                <div className="flex gap-2">
-                  <Button
+                <input
+                  type="email"
+                  value={betaEmail}
+                  onChange={(e) => setBetaEmail(e.target.value)}
+                  required
+                  placeholder="you@example.com"
+                  className="w-full h-12 px-5 bg-surface-container-highest rounded-2xl border-none text-on-surface placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all"
+                />
+                <input
+                  type="text"
+                  value={betaName}
+                  onChange={(e) => setBetaName(e.target.value)}
+                  placeholder="Your name (optional)"
+                  className="w-full h-12 px-5 bg-surface-container-highest rounded-2xl border-none text-on-surface placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all"
+                />
+                <div className="flex gap-3">
+                  <button
                     type="submit"
                     disabled={betaLoading}
-                    className="flex-1"
+                    className="flex-1 h-12 bg-gradient-to-br from-[#4edea3] to-[#10b981] text-[#00432c] font-headline font-bold rounded-full hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 transition-all"
                   >
-                    {betaLoading ? "Submitting..." : "Request Access"}
-                  </Button>
-                  <Button
+                    {betaLoading ? "Submitting…" : "Request Access"}
+                  </button>
+                  <button
                     type="button"
                     onClick={() => {
                       setShowBetaForm(false)
                       setBetaEmail("")
                       setBetaName("")
                     }}
-                    variant="outline"
+                    className="px-5 h-12 rounded-full bg-surface-container-highest text-on-surface-variant font-medium text-sm hover:text-on-surface transition-colors"
                   >
                     Cancel
-                  </Button>
+                  </button>
                 </div>
               </form>
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+
+        {/* Footer identity anchor */}
+        <p className="mt-8 text-center font-headline text-[10px] uppercase tracking-[0.2em] text-outline-variant">
+          Authorized Access Only
+        </p>
+      </div>
+    </>
   )
 }

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -4,11 +4,8 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { toast } from "sonner"
+import { Mail, Lock, ShieldCheck, ArrowRight } from "lucide-react"
 
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { supabase } from "@/lib/supabase/client"
 import { useAnalytics } from "@/contexts/AnalyticsContext"
 import { FEATURE_FLAGS } from "@/config/features"
@@ -18,6 +15,7 @@ export default function SignupPage() {
   const analytics = useAnalytics()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
   const [isLoading, setIsLoading] = useState(false)
 
   // Redirect to home if in private beta mode
@@ -44,6 +42,10 @@ export default function SignupPage() {
       toast.error("Email and password are required")
       return
     }
+    if (password !== confirmPassword) {
+      toast.error("Passwords don't match")
+      return
+    }
     setIsLoading(true)
 
     try {
@@ -57,7 +59,6 @@ export default function SignupPage() {
 
       if (error) throw error
 
-      // Track signup completion
       const { source, campaign, medium, cac_estimate } = analytics.getAcquisitionSource()
       analytics.trackEvent("signup_completed", {
         source,
@@ -69,9 +70,9 @@ export default function SignupPage() {
       toast.success("Account created! Check your email to confirm your account.", {
         duration: Infinity,
       })
-      // Don't redirect yet - user needs to confirm email first
       setEmail("")
       setPassword("")
+      setConfirmPassword("")
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Sign up failed. Try again."
@@ -82,63 +83,156 @@ export default function SignupPage() {
   }
 
   return (
-      <Card className="w-full max-w-md mx-auto border border-[var(--border-default)] bg-[var(--surface)] shadow-xl">
-        <CardHeader className="space-y-3">
-          <CardTitle className="text-2xl font-semibold text-white">
-            Create your account
-          </CardTitle>
-          <p className="text-sm text-on-surface">Week 1: add your cards + churn target</p>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <form onSubmit={handleSignup} className="space-y-4" name="signup">
-            <div className="space-y-2">
-              <Label htmlFor="email" className="text-on-surface">
-                Email
-              </Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                autoComplete="email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                required
-                placeholder="you@example.com"
-                className="border-[var(--border-default)] bg-[var(--surface-soft)] text-white placeholder:text-on-surface-variant"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password" className="text-on-surface">
-                Password
-              </Label>
-              <Input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="new-password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                required
-                placeholder="At least 6 characters"
-                className="border-[var(--border-default)] bg-[var(--surface-soft)] text-white placeholder:text-on-surface-variant"
-              />
-            </div>
-            <Button
-              type="submit"
-              className="w-full text-white"
-              style={{ background: "var(--gradient-cta)" }}
-              disabled={isLoading || !email || !password}
-            >
-              {isLoading ? "Creating..." : "Create account"}
-            </Button>
-          </form>
-          <div className="mt-4 text-center text-sm text-on-surface">
-            Already have an account?{" "}
-            <Link href="/login" className="text-[var(--accent-strong)] underline">
-              Log in
-            </Link>
+    <>
+      {/* Ambient glow blobs */}
+      <div
+        className="pointer-events-none fixed -top-24 -left-24 w-[500px] h-[500px] rounded-full blur-[120px] z-0"
+        style={{ background: "rgba(101,243,182,0.08)" }}
+      />
+      <div
+        className="pointer-events-none fixed -bottom-24 -right-24 w-[500px] h-[500px] rounded-full blur-[120px] z-0"
+        style={{ background: "rgba(208,188,255,0.05)" }}
+      />
+
+      <div className="relative z-10 w-full max-w-md px-6">
+        {/* Brand header */}
+        <div className="flex flex-col items-center mb-10">
+          <div className="mb-4">
+            <span className="text-4xl font-extrabold text-primary tracking-tighter font-headline">R</span>
           </div>
-        </CardContent>
-      </Card>
+          <h1 className="font-headline text-3xl font-extrabold tracking-tight text-center text-on-surface">
+            Reward Relay
+          </h1>
+          <p className="text-on-surface-variant mt-2 text-sm font-medium">
+            Join the Sovereign Ledger
+          </p>
+        </div>
+
+        {/* Glass card */}
+        <div className="glass-card rounded-2xl p-8 md:p-10 shadow-[0px_24px_48px_-12px_rgba(0,0,0,0.4)]">
+          {/* Beta badge */}
+          <div className="flex justify-center mb-8">
+            <div className="inline-flex items-center px-3 py-1 rounded-full bg-primary/10 border border-primary/20">
+              <span className="text-[10px] font-bold uppercase tracking-widest text-primary">
+                Private Beta — Invite Only
+              </span>
+            </div>
+          </div>
+
+          <form onSubmit={handleSignup} name="signup" className="space-y-5">
+            {/* Email */}
+            <div className="space-y-2">
+              <label
+                htmlFor="email"
+                className="block text-[10px] uppercase tracking-wider font-bold text-on-surface-variant px-1"
+              >
+                Email Address
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-outline pointer-events-none" />
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  placeholder="name@company.com"
+                  className="w-full h-12 pl-12 pr-4 bg-surface-container-highest/50 border-none rounded-2xl text-on-surface placeholder:text-outline/50 focus:outline-none focus:ring-1 focus:ring-primary/30 transition-all"
+                />
+              </div>
+            </div>
+
+            {/* Password */}
+            <div className="space-y-2">
+              <label
+                htmlFor="password"
+                className="block text-[10px] uppercase tracking-wider font-bold text-on-surface-variant px-1"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-outline pointer-events-none" />
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  placeholder="••••••••"
+                  className="w-full h-12 pl-12 pr-4 bg-surface-container-highest/50 border-none rounded-2xl text-on-surface placeholder:text-outline/50 focus:outline-none focus:ring-1 focus:ring-primary/30 transition-all"
+                />
+              </div>
+            </div>
+
+            {/* Confirm password */}
+            <div className="space-y-2">
+              <label
+                htmlFor="confirm-password"
+                className="block text-[10px] uppercase tracking-wider font-bold text-on-surface-variant px-1"
+              >
+                Confirm Password
+              </label>
+              <div className="relative">
+                <ShieldCheck className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-outline pointer-events-none" />
+                <input
+                  id="confirm-password"
+                  name="confirm-password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  placeholder="••••••••"
+                  className="w-full h-12 pl-12 pr-4 bg-surface-container-highest/50 border-none rounded-2xl text-on-surface placeholder:text-outline/50 focus:outline-none focus:ring-1 focus:ring-primary/30 transition-all"
+                />
+              </div>
+            </div>
+
+            {/* CTA */}
+            <button
+              type="submit"
+              disabled={isLoading || !email || !password || !confirmPassword}
+              className="w-full h-14 mt-4 bg-gradient-to-br from-[#4edea3] to-[#10b981] text-[#00432c] font-headline font-bold rounded-full hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2 group shadow-lg shadow-primary/20"
+            >
+              {isLoading ? "Creating account…" : "Create account"}
+              {!isLoading && (
+                <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
+              )}
+            </button>
+
+            {/* Terms */}
+            <p className="text-center text-[11px] text-on-surface-variant leading-relaxed mt-6 px-4">
+              By clicking Create account, you agree to our{" "}
+              <Link href="/terms" className="text-primary hover:underline underline-offset-2">
+                Terms of Service
+              </Link>{" "}
+              and acknowledge our{" "}
+              <Link href="/privacy" className="text-primary hover:underline underline-offset-2">
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </form>
+
+          <div className="mt-8 pt-8 border-t border-outline-variant/15 flex flex-col items-center">
+            <p className="text-on-surface-variant text-sm">
+              Already have an account?{" "}
+              <Link href="/login" className="text-primary font-bold ml-1 hover:underline underline-offset-4">
+                Sign In
+              </Link>
+            </p>
+          </div>
+        </div>
+
+        {/* Bottom branding */}
+        <div className="mt-12 text-center text-[10px] text-outline uppercase tracking-widest font-medium">
+          © 2024 Reward Relay • Secure Sovereign Ledger • All Rights Reserved
+        </div>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

Ports Financial Luminary login and signup screen designs from Stitch HTML exports. Preserves the Supabase auth data layer entirely.

**Login page (`/login`)**
- Glass card panel (`glass-card` utility) with ambient glow blobs
- Brand section: Zap icon in surface-container-highest pill + "Reward Relay" headline + "The Sovereign Ledger of Prestige" subtitle
- Email/password inputs: `h-14`, icon on left, uppercase tracking labels, `bg-surface-container-highest rounded-2xl border-none focus:ring-primary/20`
- "Forgot Password?" uppercase link inline with password label
- CTA: `rounded-full bg-gradient-to-br from-[#4edea3] to-[#10b981]` with ArrowRight icon + `hover:scale-[1.02]`
- Beta request form stays collapsible below footer divider
- "Authorized Access Only" footer identity anchor

**Signup page (`/signup`)**
- Same glass card + ambient glow blobs
- "R" monogram brand header + subtitle
- "Private Beta — Invite Only" pill badge
- Three fields: email, password, confirm password (with password match validation)
- Same gradient CTA button + ArrowRight icon
- Terms of Service / Privacy Policy inline links
- "Already have an account? Sign In" footer

## What's preserved
- `supabase.auth.signInWithPassword` / `supabase.auth.signUp` calls unchanged
- Beta request Supabase insert (`beta_requests` table)
- Analytics tracking (`signup_started`, `signup_completed`)
- `FEATURE_FLAGS.privateBeta` redirect guard
- All React state management

## Test plan
- [ ] `/login` — glass card renders, form submits with correct credentials → redirect to `/dashboard`
- [ ] `/login` — "Sign up" footer opens beta request inline form
- [ ] `/login` — "Forgot Password?" links to `/reset-password`
- [ ] `/signup` — password mismatch shows toast error, does not submit
- [ ] `/signup` — successful submit shows "check email" toast
- [ ] No TypeScript errors in auth files