### PR TITLE
feat(design): port dashboard + cards to Financial Luminary spec

### DIFF
--- a/app/src/app/cards/page.tsx
+++ b/app/src/app/cards/page.tsx
@@ -1,428 +1,474 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
-import { Wifi } from "lucide-react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { CreditCard, Plus } from "lucide-react"
 
 import { AddCardForm } from "@/components/cards/AddCardForm"
-import { CardFilters } from "@/components/cards/CardFilters"
-import { type CardRecord } from "@/components/cards/CardGrid"
-import { CardsEmptyState } from "@/components/cards/CardsEmptyState"
+import type { CardRecord } from "@/components/cards/CardGrid"
 import { AppShell } from "@/components/layout/AppShell"
 import { useCatalog } from "@/contexts/CatalogContext"
 import { getBankGradient } from "@/lib/bank-gradients"
 import { supabase } from "@/lib/supabase/client"
+import type { Database } from "@/types/database.types"
 
-function CatalogCardThumb({ card, selected, onClick }: { card: CardRecord; selected: boolean; onClick: () => void }) {
-  const gradient = getBankGradient(card.bank)
-  const isLight = card.bank === "CommBank"
-  const textColor = isLight ? "text-black/80" : "text-white"
-  const textMuted = isLight ? "text-black/50" : "text-white/60"
+type UserCard = Database["public"]["Tables"]["user_cards"]["Row"]
+type CatalogCard = Database["public"]["Tables"]["cards"]["Row"]
 
-  return (
-    <div className="group cursor-pointer" onClick={onClick}>
-      <div
-        className={`relative aspect-[1.586/1] w-full rounded-xl p-6 flex flex-col justify-between shadow-2xl transition-all duration-300 group-hover:-translate-y-2 group-hover:shadow-primary/10 overflow-hidden${selected ? " ring-2 ring-primary" : ""}`}
-        style={{ background: gradient }}
-      >
-        <div className="absolute inset-0 bg-white/5 opacity-50 mix-blend-overlay" />
-        <div className={`flex justify-between items-start relative z-10 ${textColor}`}>
-          <div className="text-xs font-bold tracking-[0.2em] text-white/80">{card.bank}</div>
-          <Wifi className="h-4 w-4 rotate-90 opacity-40 text-white" />
-        </div>
-        <div className="flex justify-between items-end relative z-10">
-          <div className={`text-sm font-headline font-bold tracking-widest ${textColor}`}>{card.name}</div>
-          {card.welcome_bonus_points ? (
-            <div className={`text-[10px] tabular-nums ${textMuted}`}>
-              {card.welcome_bonus_points.toLocaleString()} {card.points_currency ?? "pts"}
-            </div>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  )
+function getCardStatus(card: UserCard): "ACTIVE" | "BEHIND" | "CANCEL SOON" {
+  if (card.cancellation_date) {
+    const daysLeft = (new Date(card.cancellation_date).getTime() - Date.now()) / 86_400_000
+    if (daysLeft >= 0 && daysLeft <= 30) return "CANCEL SOON"
+  }
+  if (!card.bonus_earned && card.bonus_spend_deadline && card.application_date) {
+    const total = new Date(card.bonus_spend_deadline).getTime() - new Date(card.application_date).getTime()
+    const elapsed = Date.now() - new Date(card.application_date).getTime()
+    const expectedPct = total > 0 ? Math.min(100, (elapsed / total) * 100) : 0
+    // We don't know the target here without catalog, so just use deadline proximity
+    const daysLeft = (new Date(card.bonus_spend_deadline).getTime() - Date.now()) / 86_400_000
+    if (daysLeft < 14 && daysLeft >= 0) return "BEHIND"
+  }
+  return "ACTIVE"
+}
+
+function statusColor(status: string) {
+  if (status === "CANCEL SOON") return "text-error"
+  if (status === "BEHIND") return "text-yellow-400"
+  return "text-primary"
+}
+
+function statusDot(status: string) {
+  if (status === "CANCEL SOON") return "bg-error"
+  if (status === "BEHIND") return "bg-yellow-400"
+  return "bg-primary"
 }
 
 export default function CardsPage() {
-  const { catalogCards: allCards, loading: catalogLoading } = useCatalog()
-  const [cards, setCards] = useState<CardRecord[]>([])
+  const router = useRouter()
+  const { catalogCards } = useCatalog()
+  const [userCards, setUserCards] = useState<UserCard[]>([])
   const [loading, setLoading] = useState(true)
-  const [search, setSearch] = useState("")
-  const [bank, setBank] = useState<string | null>(null)
-  const [userCardCount, setUserCardCount] = useState<number | null>(null)
-  const [selectedCard, setSelectedCard] = useState<CardRecord | null>(null)
   const [showAddForm, setShowAddForm] = useState(false)
+  const [selectedCard, setSelectedCard] = useState<UserCard | null>(null)
+  const [catalogMap, setCatalogMap] = useState<Map<string, CatalogCard>>(new Map())
 
   useEffect(() => {
-    const checkAuth = async () => {
+    if (catalogCards.length > 0) {
+      setCatalogMap(new Map(catalogCards.map((c) => [c.id, c])))
+    }
+  }, [catalogCards])
+
+  useEffect(() => {
+    const load = async () => {
       const {
         data: { session },
       } = await supabase.auth.getSession()
+
       if (!session) {
-        window.location.href = `/login?redirect=${encodeURIComponent("/cards")}`
+        router.replace(`/login?redirect=${encodeURIComponent("/cards")}`)
         return
       }
 
-      // Check if user has any tracked cards for empty state
-      const { count } = await supabase
+      const { data, error } = await supabase
         .from("user_cards")
-        .select("id", { count: "exact", head: true })
-        .eq("user_id", session.user.id)
-      setUserCardCount(count ?? 0)
+        .select("*")
+        .order("created_at", { ascending: false })
+
+      if (error) {
+        toast.error(error.message || "Unable to load cards")
+        setLoading(false)
+        return
+      }
+
+      setUserCards(data ?? [])
+      if (data && data.length > 0) {
+        setSelectedCard(data[0])
+      }
       setLoading(false)
     }
-    checkAuth()
-  }, [])
+    load()
+  }, [router])
 
-  useEffect(() => {
-    // Map catalog cards to the CardRecord format
-    if (allCards.length > 0) {
-      const mapped = allCards.map(card => ({
-        id: card.id,
-        bank: card.bank,
-        name: card.name,
-        annual_fee: card.annual_fee,
-        welcome_bonus_points: card.welcome_bonus_points,
-        points_currency: card.points_currency,
-        min_income: card.min_income
-      }))
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setCards(mapped)
+  // Derived catalog card info for a given user card
+  const getCatalogCard = (uc: UserCard) => (uc.card_id ? catalogMap.get(uc.card_id) : undefined)
+
+  // Stats
+  const stats = useMemo(() => {
+    let totalLimit = 0
+    let totalSpend = 0
+    let totalPoints = 0
+    for (const uc of userCards) {
+      totalSpend += uc.current_spend ?? 0
+      const cc = uc.card_id ? catalogMap.get(uc.card_id) : undefined
+      if (cc?.welcome_bonus_points) totalPoints += cc.welcome_bonus_points
     }
-  }, [allCards])
+    return { totalLimit, totalSpend, totalPoints, count: userCards.length }
+  }, [userCards, catalogMap])
 
-  const filtered = useMemo(() => {
-    return cards.filter((card) => {
-      const matchesBank = bank ? card.bank === bank : true
-      const matchesSearch =
-        !search ||
-        card.name.toLowerCase().includes(search.toLowerCase()) ||
-        card.bank.toLowerCase().includes(search.toLowerCase())
-      return matchesBank && matchesSearch
-    })
-  }, [cards, bank, search])
+  const activeCount = userCards.filter((c) => c.status === "active").length
 
-  const uniqueBanks = useMemo(
-    () => new Set(filtered.map((c) => c.bank)).size,
-    [filtered],
-  )
+  if (loading) {
+    return (
+      <AppShell>
+        <div className="space-y-5">
+          <div className="h-20 animate-pulse rounded-xl bg-surface-container" />
+          <div className="grid grid-cols-3 gap-4">
+            {[1, 2, 3].map((i) => <div key={i} className="h-24 animate-pulse rounded-xl bg-surface-container" />)}
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            {[1, 2, 3, 4].map((i) => <div key={i} className="h-40 animate-pulse rounded-xl bg-surface-container" />)}
+          </div>
+        </div>
+      </AppShell>
+    )
+  }
 
   return (
     <AppShell>
       {/* ── Header ── */}
-      <header className="sticky top-0 w-full z-40 bg-[#0f131f]/50 backdrop-blur-md border-b border-white/5 -mx-4 md:-mx-8 px-4 md:px-0">
-        <div className="flex items-center justify-between px-8 h-20 w-full max-w-[1440px] mx-auto">
+      <header className="sticky top-0 w-full z-40 bg-[#0f131f]/50 backdrop-blur-md border-b border-white/5 -mx-4 md:-mx-8 px-4 md:px-0 mb-8">
+        <div className="flex items-center justify-between px-4 md:px-8 h-20 w-full max-w-[1440px] mx-auto">
           <div>
             <h1 className="font-headline text-2xl font-black bg-gradient-to-br from-[#4edea3] to-[#10b981] bg-clip-text text-transparent">
               Card Portfolio
             </h1>
             <p className="text-xs text-on-surface-variant font-medium">
-              {userCardCount !== null ? `${userCardCount} Active Lines of Credit` : "Card Catalog"}
+              {activeCount} Active Line{activeCount !== 1 ? "s" : ""} of Credit
             </p>
           </div>
           <button
             onClick={() => setShowAddForm((v) => !v)}
-            className="px-5 py-2 rounded-full bg-gradient-to-br from-[#4edea3] to-[#10b981] text-sm font-bold text-black hover:opacity-90 transition-opacity shadow-lg shadow-primary/20"
+            className="flex items-center gap-2 px-5 py-2.5 rounded-full font-bold text-sm text-black shadow-lg shadow-primary/20 hover:opacity-90 transition-opacity"
+            style={{ background: "var(--gradient-cta)" }}
           >
-            {showAddForm ? "Cancel" : "+ Add Card"}
+            <Plus className="h-4 w-4" />
+            {showAddForm ? "Cancel" : "Add Card"}
           </button>
         </div>
       </header>
 
-      {/* ── Value-driven empty state when no cards tracked yet ── */}
-      {userCardCount === 0 && <CardsEmptyState />}
-
-      {/* ── Add Card Form — collapsible ── */}
+      {/* ── Add Card Form ── */}
       {showAddForm && (
-        <AddCardForm cards={cards} onCreated={() => {
-          setUserCardCount((c) => (c ?? 0) + 1)
-          setShowAddForm(false)
-          window.location.href = '/dashboard';
-        }} />
-      )}
-
-      <CardFilters
-        cards={cards}
-        onFilter={({ search, bank }) => {
-          setSearch(search)
-          setBank(bank)
-        }}
-      />
-
-      {/* ── Mobile Layout (Stitch design) ── */}
-      {!loading && (
-        <div className="md:hidden space-y-8 pb-4">
-          {/* Page header */}
-          <div className="pt-2">
-            <h2 className="font-headline text-3xl font-extrabold tracking-tight text-on-surface">
-              Card Portfolio
-            </h2>
-            <p className="text-on-surface-variant text-sm font-medium mt-1">
-              {cards.length} Cards Available
-              {filtered.length < cards.length ? ` • ${filtered.length} shown` : ""}
-            </p>
-          </div>
-
-          {/* Horizontal wallet carousel */}
-          <div className="flex overflow-x-auto scrollbar-hide snap-x snap-mandatory gap-6 -mx-4 px-4 pb-2">
-            {filtered.slice(0, 8).map((card) => {
-              const gradient = getBankGradient(card.bank)
-              const isLight = card.bank === "CommBank"
-              const textMuted = isLight ? "text-black/50" : "text-white/70"
-              const bonusPts = card.welcome_bonus_points ?? 0
-              const feeLabel = card.annual_fee != null ? `$${card.annual_fee.toLocaleString()} annual fee` : "No annual fee"
-
-              return (
-                <button
-                  key={card.id}
-                  className={`snap-center shrink-0 w-[310px] aspect-[1.58/1] rounded-xl relative overflow-hidden shadow-[0_24px_48px_-12px_rgba(0,0,0,0.6)] p-6 flex flex-col justify-between text-left transition-all duration-200 ${
-                    selectedCard?.id === card.id ? "ring-2 ring-primary" : ""
-                  }`}
-                  style={{ background: gradient }}
-                  onClick={() => setSelectedCard(card)}
-                >
-                  <div className="absolute inset-0 bg-white/5 mix-blend-overlay pointer-events-none" />
-                  {/* Card top row */}
-                  <div className="relative z-10 flex justify-between items-start">
-                    <div>
-                      <p className="text-[10px] font-bold uppercase tracking-widest text-white/80">
-                        {card.bank}
-                      </p>
-                      <p className="text-xs font-medium text-white/60 mt-0.5">{card.name}</p>
-                    </div>
-                    <span className="text-[10px] font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-full uppercase tracking-tighter">
-                      Active
-                    </span>
-                  </div>
-                  {/* Card bottom row */}
-                  <div className="relative z-10 flex flex-col gap-2">
-                    <div className="flex justify-between items-end">
-                      <span className="text-2xl font-bold font-headline text-white tabular-nums">
-                        {bonusPts > 0 ? bonusPts.toLocaleString() : "—"}
-                      </span>
-                      {bonusPts > 0 && (
-                        <span className="text-[10px] font-bold text-primary">
-                          {card.points_currency ?? "pts"}
-                        </span>
-                      )}
-                    </div>
-                    <div className="w-full bg-white/10 h-1.5 rounded-full overflow-hidden">
-                      <div className="bg-primary h-full" style={{ width: bonusPts > 0 ? "75%" : "0%" }} />
-                    </div>
-                    <p className={`text-[10px] ${textMuted}`}>{feeLabel}</p>
-                  </div>
-                </button>
-              )
-            })}
-          </div>
-
-          {/* Selected card detail (if selected) */}
-          {selectedCard && (
-            <div className="bg-surface-container rounded-xl p-4 border border-white/5">
-              <div className="flex items-center justify-between mb-3">
-                <div>
-                  <p className="text-sm font-bold text-on-surface">{selectedCard.name}</p>
-                  <p className="text-xs text-on-surface-variant">{selectedCard.bank}</p>
-                </div>
-                <button
-                  className="text-[10px] text-on-surface-variant hover:text-on-surface"
-                  onClick={() => setSelectedCard(null)}
-                >
-                  ✕
-                </button>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                {selectedCard.welcome_bonus_points != null && (
-                  <div className="bg-surface-container-high rounded-lg p-3">
-                    <p className="text-[10px] uppercase font-bold text-on-surface-variant tracking-wider">Welcome Bonus</p>
-                    <p className="text-base font-bold text-primary tabular-nums mt-1">
-                      {selectedCard.welcome_bonus_points.toLocaleString()} {selectedCard.points_currency ?? "pts"}
-                    </p>
-                  </div>
-                )}
-                {selectedCard.annual_fee != null && (
-                  <div className="bg-surface-container-high rounded-lg p-3">
-                    <p className="text-[10px] uppercase font-bold text-on-surface-variant tracking-wider">Annual Fee</p>
-                    <p className="text-base font-bold text-on-surface tabular-nums mt-1">
-                      ${selectedCard.annual_fee.toLocaleString()}
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Next Rewards — top cards by bonus */}
-          <section>
-            <div className="flex justify-between items-center mb-4">
-              <h3 className="text-sm font-bold uppercase tracking-widest text-primary font-headline">
-                Top Bonuses
-              </h3>
-              <span className="text-[10px] font-semibold text-on-surface-variant">
-                {filtered.length} cards
-              </span>
-            </div>
-            <div className="space-y-3">
-              {filtered
-                .filter((c) => c.welcome_bonus_points != null)
-                .sort((a, b) => (b.welcome_bonus_points ?? 0) - (a.welcome_bonus_points ?? 0))
-                .slice(0, 3)
-                .map((card) => {
-                  const gradient = getBankGradient(card.bank)
-                  return (
-                    <button
-                      key={card.id}
-                      className="w-full bg-surface-container rounded-xl p-4 flex items-center justify-between text-left active:bg-surface-container-high transition-colors"
-                      onClick={() => setSelectedCard(card)}
-                    >
-                      <div className="flex items-center gap-4">
-                        <div
-                          className="w-10 h-10 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
-                          style={{ background: gradient }}
-                        >
-                          {card.bank.slice(0, 2).toUpperCase()}
-                        </div>
-                        <div>
-                          <p className="text-sm font-bold text-on-surface">{card.name}</p>
-                          <p className="text-xs text-on-surface-variant">{card.bank}</p>
-                        </div>
-                      </div>
-                      <div className="text-right shrink-0">
-                        <p className="text-xs font-bold text-primary">
-                          {(card.welcome_bonus_points ?? 0).toLocaleString()} pts
-                        </p>
-                        {card.annual_fee != null && (
-                          <p className="text-[10px] text-on-surface-variant">${card.annual_fee.toLocaleString()} fee</p>
-                        )}
-                      </div>
-                    </button>
-                  )
-                })}
-            </div>
-          </section>
-
-          {/* Insights Bento */}
-          <section>
-            <h3 className="text-sm font-bold uppercase tracking-widest text-on-surface-variant font-headline mb-4">
-              Portfolio Insights
-            </h3>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="bg-surface-container-low p-4 rounded-xl flex flex-col gap-3">
-                <p className="text-primary text-xl font-bold">↑</p>
-                <div>
-                  <p className="text-[10px] uppercase font-bold text-on-surface-variant tracking-wider">
-                    Highest Bonus
-                  </p>
-                  <p className="text-lg font-bold text-on-surface tabular-nums">
-                    {filtered.length > 0
-                      ? `${Math.round(Math.max(...filtered.map((c) => c.welcome_bonus_points ?? 0)) / 1000)}k pts`
-                      : "—"}
-                  </p>
-                </div>
-              </div>
-              <div className="bg-surface-container-low p-4 rounded-xl flex flex-col gap-3">
-                <p className="text-on-surface-variant text-xl font-bold">$</p>
-                <div>
-                  <p className="text-[10px] uppercase font-bold text-on-surface-variant tracking-wider">
-                    Banks Available
-                  </p>
-                  <p className="text-lg font-bold text-on-surface">{uniqueBanks}</p>
-                </div>
-              </div>
-            </div>
-          </section>
+        <div className="mb-8">
+          <AddCardForm
+            cards={catalogCards.map((c) => ({
+              id: c.id,
+              bank: c.bank,
+              name: c.name,
+              annual_fee: c.annual_fee,
+              welcome_bonus_points: c.welcome_bonus_points,
+              points_currency: c.points_currency,
+              min_income: c.min_income,
+            }))}
+            onCreated={() => {
+              setShowAddForm(false)
+              // Reload user cards
+              supabase
+                .from("user_cards")
+                .select("*")
+                .order("created_at", { ascending: false })
+                .then(({ data }) => {
+                  if (data) {
+                    setUserCards(data)
+                    if (data.length > 0) setSelectedCard(data[0])
+                  }
+                })
+            }}
+          />
         </div>
       )}
 
-      {/* ── Desktop: Stitch xl:col-span-8/4 grid ── */}
-      <div className="hidden md:block">
-        {loading ? (
-          <div className="space-y-5">
-            <div className="h-14 animate-pulse rounded-xl bg-surface-container" />
-            <div className="h-48 animate-pulse rounded-xl bg-surface-container" />
+      {/* ── Empty state ── */}
+      {userCards.length === 0 && !showAddForm && (
+        <div className="flex flex-col items-center justify-center py-20 text-center gap-6">
+          <div className="w-20 h-20 rounded-full bg-surface-container flex items-center justify-center">
+            <CreditCard className="h-10 w-10 text-on-surface-variant" />
           </div>
-        ) : (
-          <div className="p-8 flex-1 grid grid-cols-1 xl:grid-cols-12 gap-8 max-w-[1440px] mx-auto w-full -mx-8">
-            {/* Left col: xl:col-span-8 */}
-            <div className="xl:col-span-8 space-y-10">
-              {/* Stats row */}
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div className="bg-surface-container p-6 rounded-lg relative overflow-hidden group">
-                  <div className="relative z-10">
-                    <div className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-2">Total Cards</div>
-                    <div className="text-3xl font-headline font-bold tabular-nums text-on-surface">{cards.length}</div>
-                  </div>
-                </div>
-                <div className="bg-surface-container p-6 rounded-lg relative overflow-hidden group">
-                  <div className="relative z-10">
-                    <div className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-2">Showing</div>
-                    <div className="text-3xl font-headline font-bold tabular-nums text-primary">{filtered.length}</div>
-                  </div>
-                </div>
-                <div className="bg-surface-container p-6 rounded-lg relative overflow-hidden group">
-                  <div className="relative z-10">
-                    <div className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-2">Banks</div>
-                    <div className="text-3xl font-headline font-bold tabular-nums text-on-surface">{uniqueBanks}</div>
-                  </div>
+          <div>
+            <h2 className="text-xl font-bold text-on-surface mb-2">Add your first card</h2>
+            <p className="text-on-surface-variant text-sm max-w-sm">
+              Track your credit cards, monitor bonus spend progress, and see your points portfolio at a glance.
+            </p>
+          </div>
+          <button
+            onClick={() => setShowAddForm(true)}
+            className="px-6 py-3 rounded-full font-bold text-sm text-black shadow-lg shadow-primary/20"
+            style={{ background: "var(--gradient-cta)" }}
+          >
+            + Add your first card
+          </button>
+        </div>
+      )}
+
+      {/* ── Main portfolio grid ── */}
+      {userCards.length > 0 && (
+        <>
+          {/* Stats bar */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+            <div className="bg-surface-container p-6 rounded-lg relative overflow-hidden group">
+              <div className="absolute -right-4 -bottom-4 opacity-5 group-hover:opacity-10 transition-opacity">
+                <CreditCard className="h-24 w-24" />
+              </div>
+              <div className="relative z-10">
+                <div className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-2">Total Cards</div>
+                <div className="text-3xl font-headline font-bold tabular-nums text-on-surface">{userCards.length}</div>
+              </div>
+            </div>
+            <div className="bg-surface-container p-6 rounded-lg relative overflow-hidden group">
+              <div className="absolute -right-4 -bottom-4 opacity-5 group-hover:opacity-10 transition-opacity text-primary">
+                <span className="text-8xl font-bold">$</span>
+              </div>
+              <div className="relative z-10">
+                <div className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-2">Monthly Spend</div>
+                <div className="text-3xl font-headline font-bold tabular-nums text-primary">
+                  ${stats.totalSpend.toLocaleString("en-AU", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
                 </div>
               </div>
+            </div>
+            <div className="bg-surface-container p-6 rounded-lg relative overflow-hidden group">
+              <div className="absolute -right-4 -bottom-4 opacity-5 group-hover:opacity-10 transition-opacity text-tertiary">
+                <span className="text-8xl font-bold">✦</span>
+              </div>
+              <div className="relative z-10">
+                <div className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-2">Points Potential</div>
+                <div className="text-3xl font-headline font-bold tabular-nums text-tertiary">
+                  {stats.totalPoints >= 1000 ? `${(stats.totalPoints / 1000).toFixed(0)}k` : stats.totalPoints.toLocaleString()}
+                </div>
+              </div>
+            </div>
+          </div>
 
-              {/* Cards bento grid */}
+          {/* xl: two-column grid layout */}
+          <div className="grid grid-cols-1 xl:grid-cols-12 gap-8">
+            {/* Left: card grid xl:col-span-8 */}
+            <div className="xl:col-span-8">
               <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-6">
-                {filtered.map((card) => (
-                  <CatalogCardThumb
-                    key={card.id}
-                    card={card}
-                    selected={selectedCard?.id === card.id}
-                    onClick={() => setSelectedCard(card)}
-                  />
-                ))}
+                {userCards.map((uc) => {
+                  const cc = getCatalogCard(uc)
+                  const gradient = getBankGradient(uc.bank ?? "")
+                  const isLight = uc.bank === "CommBank"
+                  const textColor = isLight ? "rgba(0,0,0,0.9)" : "white"
+                  const textMuted = isLight ? "rgba(0,0,0,0.5)" : "rgba(255,255,255,0.6)"
+                  const spendTarget = cc?.bonus_spend_requirement ?? 0
+                  const currentSpend = uc.current_spend ?? 0
+                  const pct = spendTarget > 0 ? Math.min(100, Math.round((currentSpend / spendTarget) * 100)) : 0
+                  const hasBonus = spendTarget > 0 && !uc.bonus_earned
+                  const cardStatus = getCardStatus(uc)
+                  const isSelected = selectedCard?.id === uc.id
+
+                  return (
+                    <div
+                      key={uc.id}
+                      className={`group cursor-pointer${isSelected ? " ring-2 ring-primary rounded-xl" : ""}`}
+                      onClick={() => setSelectedCard(uc)}
+                    >
+                      {/* Card artwork tile */}
+                      <div
+                        className="relative w-full rounded-xl p-6 flex flex-col justify-between shadow-2xl transition-all duration-300 group-hover:-translate-y-2 group-hover:shadow-primary/10 overflow-hidden"
+                        style={{ background: gradient, aspectRatio: "1.586/1" }}
+                      >
+                        <div className="absolute inset-0 bg-white/5 opacity-50 mix-blend-overlay" />
+                        <div className="flex justify-between items-start relative z-10">
+                          <div className="text-xs font-bold tracking-[0.2em]" style={{ color: textMuted }}>
+                            {(uc.bank ?? "").toUpperCase()}
+                          </div>
+                          <span style={{ color: textMuted, fontSize: "1rem" }}>◎</span>
+                        </div>
+                        <div className="flex justify-between items-end relative z-10">
+                          <div className="text-sm font-headline font-bold tracking-widest" style={{ color: textColor }}>
+                            •••• •••• •••• ––––
+                          </div>
+                          <div className="text-[10px] font-bold italic" style={{ color: textColor }}>
+                            {uc.bank}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Card meta row below artwork */}
+                      <div className="mt-4 px-2 flex justify-between items-start">
+                        <div>
+                          <h3 className="text-sm font-bold text-on-surface">{uc.bank} {uc.name}</h3>
+                          <div className="flex items-center gap-2 mt-1">
+                            <span className={`w-2 h-2 rounded-full ${statusDot(cardStatus)}`} />
+                            <span className={`text-[10px] font-semibold uppercase ${statusColor(cardStatus)}`}>
+                              {uc.bonus_earned ? "Bonus Earned" : cardStatus}
+                            </span>
+                          </div>
+                        </div>
+                        {hasBonus && (
+                          <div className="text-right">
+                            <div className="text-xs font-bold text-primary tabular-nums">
+                              ${currentSpend.toLocaleString()} / ${spendTarget.toLocaleString()}
+                            </div>
+                            <div className="w-24 h-1 bg-surface-container-highest rounded-full mt-1 overflow-hidden">
+                              <div className="h-full bg-primary rounded-full" style={{ width: `${pct}%` }} />
+                            </div>
+                          </div>
+                        )}
+                        {uc.bonus_earned && cc?.welcome_bonus_points && (
+                          <div className="text-right">
+                            <div className="text-xs font-bold text-primary tabular-nums">
+                              {(cc.welcome_bonus_points / 1000).toFixed(0)}k pts
+                            </div>
+                            <div className="text-[10px] text-on-surface-variant">Earned</div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )
+                })}
+
+                {/* Add another card */}
+                <div
+                  className="border-2 border-dashed border-white/5 rounded-xl flex flex-col items-center justify-center p-8 cursor-pointer hover:bg-white/[0.02] transition-colors group"
+                  style={{ aspectRatio: "1.586/1" }}
+                  onClick={() => setShowAddForm(true)}
+                >
+                  <div className="w-12 h-12 rounded-full bg-surface-container flex items-center justify-center mb-3 group-hover:scale-110 transition-transform">
+                    <Plus className="h-5 w-5 text-on-surface-variant" />
+                  </div>
+                  <span className="text-sm font-bold text-on-surface-variant">Add Another Card</span>
+                </div>
               </div>
             </div>
 
-            {/* Right col: xl:col-span-4 detail panel */}
+            {/* Right: detail panel xl:col-span-4 */}
             <aside className="xl:col-span-4 space-y-8">
               <section className="bg-surface-container rounded-lg p-8 border border-white/5 relative overflow-hidden">
                 <div className="absolute top-0 right-0 w-32 h-32 bg-primary/10 blur-[80px] rounded-full" />
-                <h2 className="font-headline text-lg font-bold mb-6 flex items-center gap-2">Card Details</h2>
+                <h2 className="font-headline text-lg font-bold mb-6 flex items-center gap-2 text-on-surface">
+                  <CreditCard className="h-5 w-5 text-primary" />
+                  Card Details
+                </h2>
+
                 {selectedCard ? (
-                  <div className="space-y-6">
-                    <div className="flex justify-between items-center border-b border-white/5 pb-4">
-                      <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Bank</span>
-                      <span className="text-sm font-bold">{selectedCard.bank}</span>
+                  <div className="space-y-5">
+                    {/* Card preview mini */}
+                    <div
+                      className="w-full rounded-xl p-5 relative overflow-hidden"
+                      style={{ background: getBankGradient(selectedCard.bank ?? ""), aspectRatio: "1.586/1" }}
+                    >
+                      <div className="absolute inset-0 bg-white/5 opacity-50 mix-blend-overlay" />
+                      <div className="relative z-10 flex justify-between items-start">
+                        <span className="text-xs font-bold text-white/80 tracking-widest uppercase">{selectedCard.bank}</span>
+                        <span className="text-white/40">◎</span>
+                      </div>
+                      <div className="relative z-10 absolute bottom-5 left-5 right-5">
+                        <div className="text-sm font-bold text-white tracking-widest">•••• •••• •••• ––––</div>
+                        <div className="text-[10px] text-white/60 mt-1 uppercase tracking-wider">
+                          {selectedCard.bank} {selectedCard.name}
+                        </div>
+                      </div>
                     </div>
-                    <div className="flex justify-between items-center border-b border-white/5 pb-4">
-                      <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Card</span>
-                      <span className="text-sm font-bold">{selectedCard.name}</span>
+
+                    <div className="space-y-4">
+                      {selectedCard.annual_fee != null && (
+                        <div className="flex justify-between items-center border-b border-white/5 pb-4">
+                          <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Annual Fee</span>
+                          <span className="text-sm font-bold tabular-nums text-on-surface">${selectedCard.annual_fee.toLocaleString()}</span>
+                        </div>
+                      )}
+                      {selectedCard.application_date && (
+                        <div className="flex justify-between items-center border-b border-white/5 pb-4">
+                          <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Applied</span>
+                          <span className="text-sm font-bold tabular-nums text-on-surface">
+                            {new Date(selectedCard.application_date).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}
+                          </span>
+                        </div>
+                      )}
+                      {selectedCard.bonus_spend_deadline && (
+                        <div className="flex justify-between items-center border-b border-white/5 pb-4">
+                          <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Bonus Deadline</span>
+                          <span className="text-sm font-bold tabular-nums text-on-surface">
+                            {new Date(selectedCard.bonus_spend_deadline).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}
+                          </span>
+                        </div>
+                      )}
+                      {selectedCard.cancellation_date && (
+                        <div className="flex justify-between items-center border-b border-white/5 pb-4">
+                          <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Cancel By</span>
+                          <span className="text-sm font-bold tabular-nums text-error">
+                            {new Date(selectedCard.cancellation_date).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}
+                          </span>
+                        </div>
+                      )}
+                      {selectedCard.status && (
+                        <div className="flex justify-between items-center pb-2">
+                          <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Status</span>
+                          <span className="text-sm font-bold capitalize text-on-surface">{selectedCard.status}</span>
+                        </div>
+                      )}
                     </div>
-                    {selectedCard.annual_fee != null && (
-                      <div className="flex justify-between items-center border-b border-white/5 pb-4">
-                        <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Annual Fee</span>
-                        <span className="text-sm font-bold tabular-nums">${selectedCard.annual_fee.toLocaleString()}</span>
-                      </div>
-                    )}
-                    {selectedCard.welcome_bonus_points != null && (
-                      <div className="flex justify-between items-center border-b border-white/5 pb-4">
-                        <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Welcome Bonus</span>
-                        <span className="text-sm font-bold text-primary tabular-nums">
-                          {selectedCard.welcome_bonus_points.toLocaleString()} {selectedCard.points_currency ?? "pts"}
-                        </span>
-                      </div>
-                    )}
-                    {selectedCard.min_income != null && (
-                      <div className="flex justify-between items-center pb-4">
-                        <span className="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Min Income</span>
-                        <span className="text-sm font-bold tabular-nums">${selectedCard.min_income.toLocaleString()}</span>
-                      </div>
-                    )}
+
+                    {/* Bonus progress */}
+                    {(() => {
+                      const cc = getCatalogCard(selectedCard)
+                      const target = cc?.bonus_spend_requirement ?? 0
+                      const current = selectedCard.current_spend ?? 0
+                      const bonusPts = cc?.welcome_bonus_points ?? 0
+                      const pct = target > 0 ? Math.min(100, Math.round((current / target) * 100)) : 0
+                      const daysLeft = selectedCard.bonus_spend_deadline
+                        ? Math.max(0, Math.ceil((new Date(selectedCard.bonus_spend_deadline).getTime() - Date.now()) / 86400000))
+                        : null
+
+                      if (!selectedCard.bonus_earned && target > 0) {
+                        return (
+                          <div className="bg-surface-container-low p-4 rounded-xl border border-white/5 mt-4">
+                            <div className="text-xs font-bold mb-3 flex items-center gap-2 text-on-surface">
+                              ✦ Bonus Progress
+                            </div>
+                            <div className="flex justify-between text-[10px] text-on-surface-variant mb-2 uppercase tracking-tighter">
+                              <span>${current.toLocaleString()} Spent</span>
+                              <span>${target.toLocaleString()} Target</span>
+                            </div>
+                            <div className="w-full h-2 bg-surface-container-highest rounded-full overflow-hidden">
+                              <div
+                                className="h-full rounded-full"
+                                style={{ width: `${pct}%`, background: "linear-gradient(to right, var(--primary-container), var(--primary))" }}
+                              />
+                            </div>
+                            {daysLeft !== null && bonusPts > 0 && (
+                              <div className="mt-3 text-[10px] text-center text-on-surface-variant italic">
+                                Spend ${(target - current).toLocaleString()} more by {daysLeft}d to unlock {(bonusPts / 1000).toFixed(0)}k points
+                              </div>
+                            )}
+                          </div>
+                        )
+                      }
+
+                      if (selectedCard.bonus_earned && bonusPts > 0) {
+                        return (
+                          <div className="bg-primary/10 border border-primary/20 p-4 rounded-xl mt-4 text-center">
+                            <div className="text-primary font-bold text-sm">
+                              {(bonusPts / 1000).toFixed(0)}k bonus points earned!
+                            </div>
+                          </div>
+                        )
+                      }
+
+                      return null
+                    })()}
                   </div>
                 ) : (
-                  <p className="text-sm text-on-surface-variant mt-4">Select a card to view details</p>
+                  <p className="text-sm text-on-surface-variant">Select a card to view details</p>
                 )}
               </section>
+
+              {/* Browse catalog link */}
+              <div className="text-center">
+                <Link
+                  href="/cards/catalog"
+                  className="text-xs font-bold text-on-surface-variant hover:text-on-surface transition-colors uppercase tracking-widest"
+                >
+                  Browse Card Catalog →
+                </Link>
+              </div>
             </aside>
           </div>
-        )}
-      </div>
+        </>
+      )}
     </AppShell>
   )
 }

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -4,23 +4,13 @@ import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
-import { AlertTriangle, Calendar, CreditCard, TrendingUp, Zap } from "lucide-react"
+import { AlertTriangle, CreditCard, TrendingUp, Star, DollarSign, Zap } from "lucide-react"
 
 import { AppShell } from "@/components/layout/AppShell"
-import { ProGate } from "@/components/ui/ProGate"
-import { WalletCard } from "@/components/ui/WalletCard"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { StatCard } from "@/components/ui/stat-card"
-import { ActivityItem } from "@/components/ui/activity-item"
-import { ProgressBar } from "@/components/ui/progress-bar"
 import { EditCardModal } from "@/components/cards/EditCardModal"
-import { RecommendationCard } from "@/components/dashboard/RecommendationCard"
-import { DailyInsights } from "@/components/dashboard/DailyInsights"
+import { ProgressBar } from "@/components/ui/progress-bar"
 import { supabase } from "@/lib/supabase/client"
 import { getBankGradient } from "@/lib/bank-gradients"
-import { getRecommendations } from "@/lib/recommendations"
-import { GOALS, calculateMultiCardPaths } from "@/lib/projections"
 import { useCatalog } from "@/contexts/CatalogContext"
 import { useAnalytics } from "@/contexts/AnalyticsContext"
 import type { Database } from "@/types/database.types"
@@ -86,6 +76,7 @@ export default function DashboardPage() {
       loadCards(isNewLogin)
     }
     checkAndLoad()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router])
 
   const handleEditCard = (card: UserCard) => {
@@ -108,7 +99,9 @@ export default function DashboardPage() {
 
     let totalPoints = 0
     let monthlyPoints = 0
+    let yearlyFees = 0
     for (const uc of cards) {
+      if (uc.annual_fee) yearlyFees += uc.annual_fee
       if (!uc.bonus_earned || !uc.card_id) continue
       const pts = catalogById.get(uc.card_id)?.welcome_bonus_points ?? 0
       totalPoints += pts
@@ -117,11 +110,11 @@ export default function DashboardPage() {
       }
     }
 
-    const portfolioValue = totalPoints * 0.02 // 2¢ per point — AUD monetary value of earned bonuses
-    return { active, pending, total: cards.length, bonusReady, totalPoints, monthlyPoints, portfolioValue }
+    const portfolioValue = totalPoints * 0.02
+    const valueSavedYTD = portfolioValue - yearlyFees
+    return { active, pending, total: cards.length, bonusReady, totalPoints, monthlyPoints, portfolioValue, yearlyFees, valueSavedYTD }
   }, [cards, catalogCards])
 
-  // Cards chasing a bonus spend target — active, unearned, with a deadline
   const bonusChasingCards = useMemo(() => {
     const catalogById = new Map(catalogCards.map((c) => [c.id, c]))
     return cards
@@ -132,10 +125,8 @@ export default function DashboardPage() {
         bonusPoints: catalogById.get(c.card_id!)?.welcome_bonus_points ?? 0,
       }))
       .filter((c) => c.spendTarget > 0)
-      .slice(0, 2)
   }, [cards, catalogCards])
 
-  // Recently earned bonuses — for activity feed
   const recentEarned = useMemo(() => {
     const catalogById = new Map(catalogCards.map((c) => [c.id, c]))
     return cards
@@ -157,44 +148,17 @@ export default function DashboardPage() {
     })
   }, [cards])
 
-  const recommendations = useMemo(() => {
-    if (cards.length === 0 || catalogCards.length === 0) return []
-    return getRecommendations(cards, catalogCards)
-  }, [cards, catalogCards])
-
-  const topRecommendation = recommendations.length > 0 ? recommendations[0] : null
-
-  useEffect(() => {
-    if (topRecommendation && userId) {
-      analytics.trackEvent("recommendation_viewed", {
-        card_index: 0,
-        is_pro: false,
-        days_since_signup: 0,
-      })
-    }
-  }, [topRecommendation, userId, analytics])
-
-  const projection = useMemo(() => {
-    if (catalogCards.length === 0) return null
-    const goal = GOALS.domesticFlight
-    const paths = calculateMultiCardPaths(goal, cards, catalogCards, 0)
-    return paths.length > 0 ? { path: paths[0], goal } : null
-  }, [cards, catalogCards])
-
-  const displayName = email ? email.split("@")[0] : null
-
-  // Next upcoming date (cancellation or spend deadline) for mobile bento
-  const nextDeadline = useMemo(() => {
-    const all = cards
-      .filter((c) => c.cancellation_date || c.bonus_spend_deadline)
-      .map((c) => {
-        const dates = [c.cancellation_date, c.bonus_spend_deadline].filter(Boolean) as string[]
-        return Math.min(...dates.map((d) => new Date(d).getTime()))
-      })
-      .filter((t) => t > Date.now())
-      .sort((a, b) => a - b)
-    return all.length > 0 ? new Date(all[0]) : null
-  }, [cards])
+  // Cards that are behind bonus spend pace
+  const behindPaceCards = useMemo(() => {
+    return bonusChasingCards.filter((c) => {
+      if (!c.bonus_spend_deadline || !c.application_date) return false
+      const total = new Date(c.bonus_spend_deadline).getTime() - new Date(c.application_date).getTime()
+      const elapsed = Date.now() - new Date(c.application_date).getTime()
+      const expectedPct = total > 0 ? Math.min(100, (elapsed / total) * 100) : 0
+      const actualPct = c.spendTarget > 0 ? ((c.current_spend ?? 0) / c.spendTarget) * 100 : 0
+      return actualPct < expectedPct - 10
+    })
+  }, [bonusChasingCards])
 
   if (loading) {
     return (
@@ -214,591 +178,321 @@ export default function DashboardPage() {
 
   return (
     <AppShell>
-      {/* ─── Mobile Layout (Stitch design) ─── */}
-      <div className="md:hidden space-y-8 pb-4">
-        {/* Alert strip */}
-        {cancelAlerts.length > 0 && (
-          <div
-            className="flex items-center gap-3 rounded-r-xl border-l-4 px-4 py-3"
-            style={{ borderColor: "rgba(78,222,163,0.6)", background: "rgba(78,222,163,0.05)" }}
-          >
-            <AlertTriangle className="h-4 w-4 shrink-0 text-primary" />
-            <p className="text-sm font-medium text-on-surface">
-              <span className="font-semibold text-primary">{cancelAlerts[0].name}</span>{" "}
-              cancels {cancelAlerts[0].cancellation_date}
-            </p>
-          </div>
-        )}
-
-        {/* Hero Metric */}
-        <section className="flex flex-col gap-2">
-          <p className="text-on-surface-variant text-[10px] uppercase tracking-[0.2em] font-semibold">
-            Total Rewards Value
-          </p>
-          <div className="flex items-baseline gap-2">
-            <h2 className="text-[40px] font-extrabold font-headline leading-none tracking-tighter text-on-surface">
-              <span className="text-primary">$</span>
-              {stats.portfolioValue.toLocaleString("en-AU", {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })}
-            </h2>
-            <span className="text-primary font-bold text-sm">AUD</span>
-          </div>
-          <div className="flex items-center gap-2 mt-2">
-            {cards.length > 0 && (
-              <div className="flex -space-x-2">
-                {cards.slice(0, 3).map((card) => (
-                  <div
-                    key={card.id}
-                    className="w-6 h-6 rounded-full bg-surface-container-high border border-background flex items-center justify-center text-[10px] font-bold text-on-surface"
-                  >
-                    {(card.bank ?? "?").slice(0, 2).toUpperCase()}
-                  </div>
-                ))}
-              </div>
-            )}
-            <p className="text-on-surface-variant text-xs font-medium">
-              {stats.totalPoints > 0
-                ? `${stats.totalPoints.toLocaleString()} pts total`
-                : `${stats.total} card${stats.total !== 1 ? "s" : ""} tracked`}
-            </p>
-          </div>
-        </section>
-
-        {/* Wallet Swipeable Section */}
-        <section className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <h3 className="font-headline font-bold text-lg text-on-surface">Active Cards</h3>
-            <Link href="/cards" className="text-primary text-sm font-semibold">
-              Manage
-            </Link>
-          </div>
-          {cards.filter((c) => c.status === "active").length === 0 ? (
-            <div className="flex aspect-[1.58/1] w-full items-center justify-center rounded-xl border border-dashed border-primary/20 p-6">
-              <div className="text-center">
-                <CreditCard className="mx-auto h-8 w-8 text-on-surface-variant mb-2" />
-                <p className="text-on-surface-variant text-sm">No active cards</p>
-                <Link href="/cards" className="mt-2 inline-block text-primary text-xs font-semibold">
-                  Add a card →
-                </Link>
-              </div>
-            </div>
-          ) : (
-            <div className="flex overflow-x-auto scrollbar-hide gap-4 -mx-4 px-4 snap-x snap-mandatory pb-2">
-              {cards
-                .filter((c) => c.status === "active")
-                .slice(0, 5)
-                .map((card) => {
-                  const gradient = getBankGradient(card.bank ?? "")
-                  const isLight = card.bank === "CommBank"
-                  const textColor = isLight ? "text-black/80" : "text-white"
-                  const textMuted = isLight ? "text-black/50" : "text-white/60"
-                  const currentSpend = card.current_spend ?? 0
-
-                  return (
-                    <button
-                      key={card.id}
-                      className="min-w-[300px] snap-center shrink-0 aspect-[1.58/1] rounded-xl p-6 relative overflow-hidden shadow-[0_24px_48px_-12px_rgba(0,0,0,0.4)] flex flex-col justify-between text-left"
-                      style={{ background: gradient }}
-                      onClick={() => handleEditCard(card)}
-                    >
-                      <div className="absolute inset-0 bg-white/5 mix-blend-overlay pointer-events-none" />
-                      <div className={`relative z-10 flex items-start justify-between ${textColor}`}>
-                        <div>
-                          <p className="text-[10px] font-bold uppercase tracking-widest opacity-80">
-                            {card.bank}
-                          </p>
-                          <p className="text-xs font-medium opacity-60 mt-0.5">{card.name}</p>
-                        </div>
-                        <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-white/10 uppercase tracking-tighter">
-                          {card.bonus_earned ? "Earned" : "Active"}
-                        </span>
-                      </div>
-                      <div className="relative z-10">
-                        <p className={`text-[10px] uppercase tracking-widest font-semibold mb-1 ${textMuted}`}>
-                          {card.bonus_earned ? "Bonus Earned" : "Spend Progress"}
-                        </p>
-                        {!card.bonus_earned && (
-                          <div className="w-full h-1.5 bg-black/20 rounded-full overflow-hidden mb-2">
-                            <div className="h-full bg-primary rounded-full w-3/4" />
-                          </div>
-                        )}
-                        <div className={`flex justify-between ${textColor}`}>
-                          <span className="text-xs font-bold">
-                            {card.bank} {card.name}
-                          </span>
-                          {currentSpend > 0 && (
-                            <span className="text-xs font-bold">
-                              ${Math.round(currentSpend).toLocaleString()} spent
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    </button>
-                  )
-                })}
-            </div>
-          )}
-        </section>
-
-        {/* Insights Bento */}
-        <section className="flex flex-col gap-4">
-          <h3 className="font-headline font-bold text-lg text-on-surface">Daily Insights</h3>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="col-span-1 p-5 rounded-xl bg-surface-container flex flex-col gap-3">
-              <Zap className="h-5 w-5 text-primary" />
-              <div>
-                <p className="text-on-surface-variant text-[10px] uppercase font-bold tracking-wider">
-                  Bonus Ready
-                </p>
-                <p className="text-xl font-headline font-bold text-on-surface">
-                  {stats.bonusReady}
-                  <span className="text-xs ml-1 font-medium text-on-surface-variant">
-                    {stats.bonusReady === 1 ? "card" : "cards"}
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div className="col-span-1 p-5 rounded-xl bg-surface-container flex flex-col gap-3">
-              <Calendar className="h-5 w-5 text-primary" />
-              <div>
-                <p className="text-on-surface-variant text-[10px] uppercase font-bold tracking-wider">
-                  Due Soon
-                </p>
-                <p className="text-xl font-headline font-bold text-on-surface">
-                  {nextDeadline
-                    ? nextDeadline.toLocaleDateString("en-AU", { day: "numeric", month: "short" })
-                    : "—"}
-                </p>
-              </div>
-            </div>
-            {/* Monthly ring tile — full width */}
-            <div className="col-span-2 p-5 rounded-xl bg-surface-container flex items-center justify-between">
-              <div className="flex flex-col gap-1">
-                <p className="text-on-surface-variant text-[10px] uppercase font-bold tracking-wider">
-                  Monthly Earned
-                </p>
-                <p className="text-lg font-headline font-bold text-on-surface">
-                  {stats.monthlyPoints.toLocaleString()} pts{" "}
-                  {stats.totalPoints > 0 && (
-                    <span className="text-primary text-xs ml-1">
-                      {Math.round((stats.monthlyPoints / Math.max(stats.totalPoints, 1)) * 100)}%
-                    </span>
-                  )}
-                </p>
-              </div>
-              <div className="w-12 h-12 shrink-0 relative">
-                <svg className="w-full h-full -rotate-90" viewBox="0 0 48 48">
-                  <circle
-                    className="text-surface-container-highest"
-                    cx="24" cy="24" r="20"
-                    fill="transparent" stroke="currentColor" strokeWidth="4"
-                  />
-                  <circle
-                    className="text-primary"
-                    cx="24" cy="24" r="20"
-                    fill="transparent" stroke="currentColor" strokeWidth="4"
-                    strokeDasharray="125.6"
-                    strokeDashoffset={
-                      125.6 * (1 - Math.min(1, stats.totalPoints > 0 ? stats.monthlyPoints / stats.totalPoints : 0))
-                    }
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Bonus Tracker */}
-        {bonusChasingCards.length > 0 && (
-          <section className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-              <h3 className="font-headline font-bold text-lg text-on-surface">Bonus Tracker</h3>
-              <Link href="/spending" className="text-primary text-sm font-semibold">
-                Track all
-              </Link>
-            </div>
-            <div className="space-y-3">
-              {bonusChasingCards.map((card) => {
-                const pct =
-                  card.spendTarget > 0
-                    ? Math.min(100, Math.round(((card.current_spend ?? 0) / card.spendTarget) * 100))
-                    : 0
-                const daysLeft = card.bonus_spend_deadline
-                  ? Math.max(0, Math.ceil((new Date(card.bonus_spend_deadline).getTime() - Date.now()) / 86400000))
-                  : null
-                return (
-                  <div key={card.id} className="bg-surface-container rounded-xl p-4">
-                    <div className="flex items-center justify-between mb-3">
-                      <div>
-                        <p className="text-sm font-bold text-on-surface">
-                          {card.bank} {card.name}
-                        </p>
-                        {daysLeft !== null && (
-                          <p className="text-[10px] text-on-surface-variant mt-0.5">{daysLeft}d remaining</p>
-                        )}
-                      </div>
-                      {card.bonusPoints > 0 && (
-                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-bold text-primary">
-                          {Math.round(card.bonusPoints / 1000)}k pts
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex justify-between text-[10px] text-on-surface-variant mb-1">
-                      <span>${Math.round(card.current_spend ?? 0).toLocaleString()} spent</span>
-                      <span>{pct}%</span>
-                    </div>
-                    <ProgressBar value={pct} />
-                    <p className="mt-1 text-[10px] text-on-surface-variant">
-                      of ${card.spendTarget.toLocaleString()} target
-                    </p>
-                  </div>
-                )
-              })}
-            </div>
-          </section>
-        )}
-
-        {/* Recent Earns */}
-        {recentEarned.length > 0 && (
-          <section className="flex flex-col gap-4">
-            <h3 className="font-headline font-bold text-lg text-on-surface">Recent Earns</h3>
-            <div className="flex flex-col divide-y divide-white/5 rounded-xl bg-surface-container overflow-hidden">
-              {recentEarned.map((card) => {
-                const earnedDate = card.bonus_earned_at
-                  ? new Date(card.bonus_earned_at).toLocaleDateString("en-AU", {
-                      day: "numeric",
-                      month: "short",
-                    })
-                  : null
-                return (
-                  <div
-                    key={card.id}
-                    className="flex items-center gap-4 px-4 py-4 active:bg-white/5 transition-colors"
-                  >
-                    <div className="w-12 h-12 rounded-full bg-surface-container-high flex items-center justify-center shrink-0">
-                      <CreditCard className="h-5 w-5 text-primary" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <h4 className="font-bold text-sm text-on-surface truncate">
-                        {card.bank} {card.name}
-                      </h4>
-                      <p className="text-xs text-on-surface-variant">Welcome Bonus</p>
-                    </div>
-                    <div className="text-right shrink-0">
-                      <p className="font-bold text-primary text-sm">
-                        +{card.bonusPoints.toLocaleString()}
-                      </p>
-                      <p className="text-[10px] text-on-surface-variant">{earnedDate ?? ""}</p>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </section>
-        )}
-
-        {/* Top recommendation */}
-        {topRecommendation && (
-          <section>
-            <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-              Top Opportunity
-            </p>
-            <RecommendationCard recommendation={topRecommendation} variant="hero" />
-          </section>
-        )}
+      {/* ── Header breadcrumb (desktop) ── */}
+      <div className="hidden md:flex items-center gap-2 text-on-surface-variant font-medium text-sm mb-2">
+        <span>Dashboard</span>
+        <span className="text-on-surface-variant">›</span>
+        <span className="text-on-surface">Overview</span>
       </div>
 
-      {/* ─── Desktop Layout ─── */}
-      <div className="hidden md:block">
-        <div className="space-y-6">
-          {/* Alert strip — cancellations within 30 days */}
-          {cancelAlerts.length > 0 && (
-            <div
-              className="flex items-center justify-between gap-4 rounded-r-xl border-l-4 px-4 py-3"
-              style={{
-                borderColor: "rgba(78,222,163,0.6)",
-                background: "rgba(78,222,163,0.05)",
-              }}
-            >
-              <div className="flex items-center gap-3">
-                <AlertTriangle className="h-4 w-4 shrink-0 text-primary" />
-                <p className="text-sm font-medium text-on-surface">
-                  <span className="font-semibold text-primary">{cancelAlerts[0].name}</span>{" "}
-                  cancels {cancelAlerts[0].cancellation_date} — take action before the date.
-                </p>
-              </div>
-              <Link href={`/dashboard/cards/${cancelAlerts[0].id}`}>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="shrink-0 rounded-full text-primary hover:bg-primary/10 hover:text-primary"
-                >
-                  Take action
-                </Button>
-              </Link>
+      <div className="space-y-10 pb-8">
+        {/* ── Alert Banner ── */}
+        {(cancelAlerts.length > 0 || behindPaceCards.length > 0) && (
+          <div
+            className="flex items-center justify-between gap-4 rounded-r-xl border-l-4 px-4 py-3"
+            style={{ borderColor: "var(--primary)", background: "rgba(78,222,163,0.06)" }}
+          >
+            <div className="flex items-center gap-3">
+              <AlertTriangle className="h-4 w-4 shrink-0 text-primary" />
+              <p className="text-sm font-medium text-on-surface">
+                {cancelAlerts.length > 0 ? (
+                  <>
+                    <span className="font-semibold text-primary">{cancelAlerts[0].name}</span>
+                    {" "}cancels {cancelAlerts[0].cancellation_date} — take action before the date.
+                  </>
+                ) : (
+                  <>
+                    <span className="font-semibold text-primary">{behindPaceCards.length} card{behindPaceCards.length !== 1 ? "s" : ""}</span>
+                    {" "}need attention — behind bonus spend pace.{" "}
+                    <Link href="/spending" className="text-primary hover:underline">Check spend now.</Link>
+                  </>
+                )}
+              </p>
             </div>
-          )}
+          </div>
+        )}
 
-          {/* Hero metric */}
-          <div className="rounded-2xl bg-surface-container p-8">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-              {displayName ? `Hey, ${displayName}` : "Dashboard"}
-            </p>
-            {stats.portfolioValue > 0 ? (
-              <div className="mt-3 flex items-baseline gap-3">
-                <span className="font-headline text-[48px] font-extrabold tabular-nums tracking-tighter text-primary md:text-6xl">
-                  ${stats.portfolioValue.toLocaleString("en-AU", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+        {/* ── Hero Metric + Stats Row ── */}
+        <section className="space-y-6">
+          <div className="flex flex-col gap-1">
+            <h2 className="text-on-surface-variant text-sm font-semibold uppercase tracking-widest">
+              Total Valuation (AUD)
+            </h2>
+            <div className="flex items-baseline gap-4 flex-wrap">
+              <span
+                className="font-headline font-extrabold tabular-nums tracking-tighter text-on-surface"
+                style={{ fontSize: "clamp(2.5rem, 6vw, 4rem)" }}
+              >
+                ${stats.portfolioValue.toLocaleString("en-AU", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+              </span>
+              {stats.totalPoints > 0 && (
+                <span className="px-3 py-1 bg-primary/10 text-primary text-xs font-bold rounded-full border border-primary/20 flex items-center gap-1">
+                  <TrendingUp className="h-3 w-3" />
+                  {stats.totalPoints.toLocaleString()} pts
                 </span>
-                <span className="text-base text-on-surface-variant">total portfolio value</span>
-              </div>
-            ) : (
-              <div className="mt-3 flex items-baseline gap-4">
-                <span className="font-headline text-[48px] font-extrabold tabular-nums tracking-tighter text-primary md:text-6xl">
-                  {stats.active}
-                </span>
-                <span className="text-base text-on-surface-variant">
-                  {stats.active === 1 ? "card" : "cards"} working for you
-                </span>
-              </div>
-            )}
-            <Button
-              size="sm"
-              className="mt-6 rounded-full font-semibold text-on-primary shadow-sm"
-              style={{ background: "var(--gradient-cta)" }}
-              onClick={() => router.push("/cards")}
-            >
-              <CreditCard className="mr-1.5 h-3.5 w-3.5" />
-              Add card
-            </Button>
+              )}
+            </div>
           </div>
 
           {/* Stats row */}
-          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-            {[
-              { label: "Total Points", value: stats.totalPoints >= 1000 ? `${Math.round(stats.totalPoints / 1000)}k` : stats.totalPoints.toString() },
-              { label: "Monthly Earning", value: stats.monthlyPoints >= 1000 ? `${Math.round(stats.monthlyPoints / 1000)}k` : stats.monthlyPoints.toString() },
-              { label: "Cards Active", value: stats.active.toString() },
-              { label: "Bonus Ready", value: stats.bonusReady.toString() },
-            ].map(({ label, value }) => (
-              <StatCard key={label} label={label} value={value} accent />
-            ))}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="bg-surface-container p-6 rounded-lg border border-white/5 space-y-2">
+              <div className="flex items-center gap-2">
+                <Star className="h-3.5 w-3.5 text-on-surface-variant" />
+                <span className="text-xs text-on-surface-variant font-bold uppercase tracking-wider">Points Sum</span>
+              </div>
+              <div className="text-xl font-bold tabular-nums text-on-surface">
+                {stats.totalPoints >= 1000 ? `${(stats.totalPoints / 1000).toFixed(0)}k` : stats.totalPoints.toLocaleString()}
+              </div>
+            </div>
+            <div className="bg-surface-container p-6 rounded-lg border border-white/5 space-y-2">
+              <div className="flex items-center gap-2">
+                <CreditCard className="h-3.5 w-3.5 text-on-surface-variant" />
+                <span className="text-xs text-on-surface-variant font-bold uppercase tracking-wider">Active Cards</span>
+              </div>
+              <div className="text-xl font-bold tabular-nums text-on-surface">{stats.active}</div>
+            </div>
+            <div className="bg-surface-container p-6 rounded-lg border border-white/5 space-y-2">
+              <div className="flex items-center gap-2">
+                <DollarSign className="h-3.5 w-3.5 text-on-surface-variant" />
+                <span className="text-xs text-on-surface-variant font-bold uppercase tracking-wider">Yearly Fees</span>
+              </div>
+              <div className="text-xl font-bold tabular-nums text-on-surface">
+                ${stats.yearlyFees > 0 ? stats.yearlyFees.toLocaleString() : "0"}
+              </div>
+            </div>
+            <div className="bg-surface-container p-6 rounded-lg border border-white/5 space-y-2">
+              <div className="flex items-center gap-2">
+                <Zap className="h-3.5 w-3.5 text-primary" />
+                <span className="text-xs text-on-surface-variant font-bold uppercase tracking-wider">Saved (YTD)</span>
+              </div>
+              <div className="text-xl font-bold tabular-nums text-primary">
+                ${Math.max(0, stats.valueSavedYTD).toLocaleString("en-AU", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Active Bonus Trackers ── */}
+        <section className="space-y-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold font-headline text-on-surface">Active Bonus Trackers</h2>
+            <Link
+              href="/spending"
+              className="text-primary text-sm font-bold hover:underline flex items-center gap-1"
+            >
+              View All Cards →
+            </Link>
           </div>
 
-          {/* Bonus tracker bento */}
-          {bonusChasingCards.length > 0 && (
-            <div>
-              <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-                Bonus Tracker
-              </p>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                {bonusChasingCards.map((card) => {
-                  const pct = card.spendTarget > 0
-                    ? Math.min(100, Math.round(((card.current_spend ?? 0) / card.spendTarget) * 100))
-                    : 0
-                  const daysLeft = card.bonus_spend_deadline
-                    ? Math.max(0, Math.ceil((new Date(card.bonus_spend_deadline).getTime() - Date.now()) / 86400000))
-                    : null
-                  return (
-                    <div key={card.id} className="glass-panel rounded-2xl p-5 transition-colors duration-200 hover:border-primary/30">
-                      <div className="flex items-start justify-between gap-2">
-                        <div>
-                          <p className="text-xs font-bold text-on-surface">{card.bank} {card.name}</p>
-                          {daysLeft !== null && (
-                            <p className="mt-0.5 text-[10px] text-on-surface-variant">{daysLeft}d remaining</p>
-                          )}
-                        </div>
-                        {card.bonusPoints > 0 && (
-                          <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-bold text-primary">
-                            {(card.bonusPoints / 1000).toFixed(0)}k pts
-                          </span>
-                        )}
+          {bonusChasingCards.length === 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+              {/* Empty state tracker slot */}
+              <div className="border-2 border-dashed border-white/5 rounded-xl flex flex-col items-center justify-center p-8 hover:bg-white/[0.02] transition-colors cursor-pointer group"
+                onClick={() => router.push("/cards")}
+              >
+                <div className="w-12 h-12 rounded-full bg-surface-container flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                  <CreditCard className="h-5 w-5 text-on-surface-variant" />
+                </div>
+                <span className="text-sm font-bold text-on-surface-variant">No active bonus trackers</span>
+                <span className="text-xs text-on-surface-variant mt-1">Add a card with a spend target to track</span>
+              </div>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+              {bonusChasingCards.map((card) => {
+                const pct = card.spendTarget > 0
+                  ? Math.min(100, Math.round(((card.current_spend ?? 0) / card.spendTarget) * 100))
+                  : 0
+                const daysLeft = card.bonus_spend_deadline
+                  ? Math.max(0, Math.ceil((new Date(card.bonus_spend_deadline).getTime() - Date.now()) / 86400000))
+                  : null
+                const gradient = getBankGradient(card.bank ?? "")
+                const bankInitials = (card.bank ?? "?").slice(0, 4).toUpperCase()
+
+                return (
+                  <div
+                    key={card.id}
+                    className="bg-surface-container p-8 rounded-xl border border-white/5 flex flex-col justify-between group hover:border-primary/30 transition-all duration-300 cursor-pointer"
+                    onClick={() => handleEditCard(card)}
+                  >
+                    <div className="flex justify-between items-start mb-12">
+                      <div className="flex flex-col gap-1">
+                        <span className="text-xs font-bold text-on-surface-variant uppercase tracking-widest">
+                          {card.bank} {card.name}
+                        </span>
+                        <h4 className="text-lg font-bold text-on-surface">
+                          {card.bonusPoints > 0
+                            ? `${(card.bonusPoints / 1000).toFixed(0)}k Bonus Points`
+                            : "Bonus Tracker"}
+                        </h4>
                       </div>
-                      <div className="mt-4">
-                        <div className="mb-1 flex justify-between text-[10px] text-on-surface-variant">
-                          <span>${Math.round(card.current_spend ?? 0).toLocaleString()} spent</span>
-                          <span>{pct}%</span>
-                        </div>
-                        <ProgressBar value={pct} />
-                        <p className="mt-1 text-[10px] text-on-surface-variant">
-                          of ${card.spendTarget.toLocaleString()} target
-                        </p>
+                      <div
+                        className="w-12 h-8 rounded-md flex items-center justify-center border border-white/10"
+                        style={{ background: gradient }}
+                      >
+                        <span className="text-[9px] font-bold text-white tracking-widest">{bankInitials}</span>
                       </div>
                     </div>
-                  )
-                })}
-                <button
-                  onClick={() => router.push("/spending")}
-                  className="flex items-center justify-center gap-2 rounded-2xl border border-dashed border-primary/20 p-5 text-sm font-semibold text-primary transition-colors hover:bg-primary/5"
-                >
-                  <CreditCard className="h-4 w-4" />
-                  Track new bonus
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* 3D wallet card stack */}
-          <div>
-            <div className="mb-4 flex items-center justify-between">
-              <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-                Your Cards
-              </p>
-              <Link href="/cards">
-                <Button size="sm" variant="ghost" className="rounded-full text-on-surface-variant hover:text-on-surface">
-                  Browse catalog
-                </Button>
-              </Link>
-            </div>
-
-            {cards.length === 0 ? (
-              <div className="glass-panel flex flex-col items-start gap-3 rounded-2xl p-6">
-                <p className="font-semibold text-on-surface">No cards tracked yet</p>
-                <p className="text-sm text-on-surface-variant">
-                  Add your current cards and churn targets to see reminders and eligibility.
-                </p>
-                <Button
-                  size="sm"
-                  onClick={() => router.push("/cards")}
-                  className="rounded-full font-semibold text-on-primary"
-                  style={{ background: "var(--gradient-cta)" }}
-                >
-                  <CreditCard className="mr-1.5 h-3.5 w-3.5" />
-                  Browse cards
-                </Button>
-              </div>
-            ) : (
-              <>
-                {cards.filter(c => c.status === "active").length >= 2 ? (
-                  <div className="relative mb-6 overflow-x-hidden" style={{ height: 180 }}>
-                    {cards
-                      .filter(c => c.status === "active")
-                      .slice(0, 3)
-                      .reverse()
-                      .map((card, revIdx, arr) => {
-                        const idx = arr.length - 1 - revIdx
-                        const rotations = ["rotate-3", "rotate-1", "-rotate-1"]
-                        const tops = [8, 4, 0]
-                        return (
-                          <div
-                            key={card.id}
-                            className={`absolute inset-x-0 ${rotations[idx] ?? ""} cursor-pointer transition-transform duration-300 hover:-translate-y-2`}
-                            style={{ top: tops[idx] ?? 0, zIndex: idx + 1 }}
-                            onClick={() => handleEditCard(card)}
-                          >
-                            <WalletCard card={card} showProgress />
-                          </div>
-                        )
-                      })}
-                  </div>
-                ) : (
-                  <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-                    {cards.map((card) => (
-                      <WalletCard key={card.id} card={card} showProgress onClick={() => handleEditCard(card)} />
-                    ))}
-                  </div>
-                )}
-                {cards.filter(c => c.status === "active").length >= 2 && (
-                  <div className="flex flex-wrap gap-2">
-                    {cards.map((card) => (
-                      <button
-                        key={card.id}
-                        onClick={() => handleEditCard(card)}
-                        className="rounded-full border border-white/5 bg-surface-container px-3 py-1 text-xs font-medium text-on-surface-variant hover:bg-surface-container-high"
-                      >
-                        {card.bank} {card.name}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-
-          {/* Recent points activity feed */}
-          {recentEarned.length > 0 && (
-            <div>
-              <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-                Recent Bonuses
-              </p>
-              <div className="glass-panel divide-y divide-white/5 rounded-2xl">
-                {recentEarned.map((card) => {
-                  const earnedDate = card.bonus_earned_at
-                    ? new Date(card.bonus_earned_at).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })
-                    : null
-                  return (
-                    <ActivityItem
-                      key={card.id}
-                      primary={`${card.bank} ${card.name}`}
-                      secondary={earnedDate ? `Earned ${earnedDate}` : undefined}
-                      value={card.bonusPoints > 0 ? `+${card.bonusPoints.toLocaleString()} pts` : undefined}
-                    />
-                  )
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* Top recommendation */}
-          {topRecommendation && (
-            <div>
-              <p className="mb-2 text-sm font-medium text-on-surface-variant">Top opportunity</p>
-              <RecommendationCard recommendation={topRecommendation} variant="hero" />
-            </div>
-          )}
-
-          {/* Projection preview */}
-          {projection && (
-            <ProGate feature="goal projections & timeline">
-              <Card className="border-primary/20 bg-surface-container shadow-sm">
-                <CardContent className="pt-5">
-                  <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                    <div className="space-y-1.5">
-                      <div className="flex items-center gap-2">
-                        <TrendingUp className="h-4 w-4 text-primary" />
-                        <p className="text-sm font-medium text-on-surface-variant">Goal projection</p>
+                    <div className="space-y-3">
+                      <div className="flex justify-between text-sm font-medium">
+                        <span className="text-on-surface-variant">Spend Progress</span>
+                        <span className="text-on-surface tabular-nums">
+                          ${Math.round(card.current_spend ?? 0).toLocaleString()} / ${card.spendTarget.toLocaleString()}
+                        </span>
                       </div>
-                      <p className="text-xl font-semibold text-on-surface">
-                        {projection.goal.label} in{" "}
-                        <span className="text-primary">{projection.path.timeToGoal} months</span>
-                      </p>
-                      <div className="flex items-center gap-3 text-xs text-on-surface-variant">
-                        <span>{projection.path.totalPoints.toLocaleString()} pts</span>
-                        <span>·</span>
-                        <span>${projection.path.totalCost} fees</span>
-                        <span>·</span>
-                        <span className="text-primary">
-                          ${projection.path.netValue.toFixed(0)} net value
+                      <ProgressBar value={pct} height="md" />
+                      <div className="flex justify-between items-center pt-2">
+                        <span className="text-[11px] text-on-surface-variant font-bold uppercase tracking-wider">
+                          {daysLeft !== null ? `${daysLeft}d remaining` : card.bonus_spend_deadline ?? ""}
+                        </span>
+                        <span className="text-primary text-xs font-bold">
+                          {pct >= 95 ? "Almost There!" : `${pct}% Done`}
                         </span>
                       </div>
                     </div>
-                    <Link href="/projections">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="rounded-full border-surface-container-highest text-on-surface hover:bg-surface-container-highest"
-                      >
-                        View all goals
-                      </Button>
-                    </Link>
                   </div>
-                </CardContent>
-              </Card>
-            </ProGate>
-          )}
+                )
+              })}
 
-          {/* Daily insights */}
-          {userId && (
-            <ProGate feature="daily insights & deals">
-              <div>
-                <p className="mb-2 text-sm font-medium text-on-surface-variant">Today&apos;s activity</p>
-                <DailyInsights userId={userId} />
+              {/* Add new tracker CTA */}
+              <div
+                className="border-2 border-dashed border-white/5 rounded-xl flex flex-col items-center justify-center p-8 hover:bg-white/[0.02] transition-colors cursor-pointer group"
+                onClick={() => router.push("/cards")}
+              >
+                <div className="w-12 h-12 rounded-full bg-surface-container flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                  <CreditCard className="h-5 w-5 text-on-surface-variant" />
+                </div>
+                <span className="text-sm font-bold text-on-surface-variant">Track New Bonus</span>
               </div>
-            </ProGate>
+            </div>
           )}
-        </div>
+        </section>
+
+        {/* ── Credit Portfolio (wallet card stack) ── */}
+        <section className="grid grid-cols-1 xl:grid-cols-3 gap-8">
+          <div className="xl:col-span-2 space-y-6">
+            <h2 className="text-2xl font-bold font-headline text-on-surface">Credit Portfolio</h2>
+
+            {cards.length === 0 ? (
+              <div className="flex aspect-[2/1] w-full items-center justify-center rounded-xl border border-dashed border-primary/20 p-6">
+                <div className="text-center">
+                  <CreditCard className="mx-auto h-10 w-10 text-on-surface-variant mb-3" />
+                  <p className="text-on-surface-variant font-semibold">No cards tracked yet</p>
+                  <Link href="/cards" className="mt-2 inline-block text-primary text-sm font-bold hover:underline">
+                    Add your first card →
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              <div className="relative w-full" style={{ height: Math.min(cards.filter(c => c.status === "active").length, 3) * 56 + 140 }}>
+                {cards
+                  .filter((c) => c.status === "active")
+                  .slice(0, 3)
+                  .reverse()
+                  .map((card, revIdx, arr) => {
+                    const idx = arr.length - 1 - revIdx
+                    const rotations = [-3, 1, -1]
+                    const tops = [idx === 0 ? 16 : idx === 1 ? 8 : 0]
+                    const gradient = getBankGradient(card.bank ?? "")
+                    const isLight = card.bank === "CommBank"
+                    const textColor = isLight ? "black" : "white"
+
+                    return (
+                      <div
+                        key={card.id}
+                        className="absolute inset-x-0 cursor-pointer transition-transform duration-300 hover:-translate-y-3"
+                        style={{
+                          top: (idx * 8),
+                          zIndex: idx + 1,
+                          transform: `rotate(${rotations[idx] ?? 0}deg)`,
+                        }}
+                        onClick={() => handleEditCard(card)}
+                      >
+                        <div
+                          className="w-full md:w-[420px] rounded-xl p-8 border border-white/10 shadow-2xl relative overflow-hidden"
+                          style={{ background: gradient, aspectRatio: "1.58/1" }}
+                        >
+                          <div className="flex justify-between items-start">
+                            <span className="text-base font-bold" style={{ color: textColor }}>{card.bank}</span>
+                            <span className="text-white/40 text-sm">◎</span>
+                          </div>
+                          <div className="absolute bottom-8 left-8 right-8">
+                            <div className="text-lg tracking-[0.2em] font-medium mb-2" style={{ color: `${textColor}`, opacity: 0.7 }}>
+                              •••• •••• •••• ––––
+                            </div>
+                            <div className="flex justify-between items-center">
+                              <div className="text-xs uppercase font-bold tracking-widest" style={{ color: textColor, opacity: 0.5 }}>
+                                {card.bank} {card.name}
+                              </div>
+                              <div
+                                className="text-xs font-bold px-2 py-0.5 rounded-full"
+                                style={{ background: "rgba(0,0,0,0.2)", color: textColor }}
+                              >
+                                {card.status?.toUpperCase() ?? "ACTIVE"}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  })}
+              </div>
+            )}
+          </div>
+
+          {/* Recent Points section */}
+          <div className="space-y-6">
+            <h2 className="text-2xl font-bold font-headline text-on-surface">Recent Points</h2>
+
+            {recentEarned.length === 0 ? (
+              <div className="bg-surface-container rounded-xl border border-white/5 p-6 text-center">
+                <p className="text-on-surface-variant text-sm">Bonuses you earn will appear here</p>
+              </div>
+            ) : (
+              <div className="bg-surface-container rounded-xl border border-white/5 divide-y divide-white/5 overflow-hidden">
+                {recentEarned.map((card) => {
+                  const earnedDate = card.bonus_earned_at
+                    ? new Date(card.bonus_earned_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })
+                    : null
+                  const gradient = getBankGradient(card.bank ?? "")
+                  return (
+                    <div
+                      key={card.id}
+                      className="p-4 flex items-center justify-between hover:bg-white/5 transition-colors"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div
+                          className="w-10 h-10 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
+                          style={{ background: gradient }}
+                        >
+                          {(card.bank ?? "?").slice(0, 2).toUpperCase()}
+                        </div>
+                        <div className="flex flex-col">
+                          <span className="text-sm font-bold text-on-surface">
+                            {card.bank} {card.name}
+                          </span>
+                          <span className="text-[10px] text-on-surface-variant uppercase font-bold">Welcome Bonus</span>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <div className="text-sm font-bold text-primary tabular-nums">
+                          {card.bonusPoints > 0 ? `+${card.bonusPoints.toLocaleString()}` : "Earned"}
+                        </div>
+                        <div className="text-[10px] text-on-surface-variant">{earnedDate ?? ""}</div>
+                      </div>
+                    </div>
+                  )
+                })}
+                <div className="p-4 text-center">
+                  <Link href="/spending" className="text-xs font-bold text-on-surface-variant hover:text-on-surface transition-colors">
+                    View All Activity
+                  </Link>
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
       </div>
 
       <EditCardModal


### PR DESCRIPTION
## Summary
- Dashboard: rewrite to match Financial Luminary layout (hero metric, stats row, alert banner, bonus trackers, credit portfolio, recent points); removes paywall overlay
- Cards: replace catalogue view with personal portfolio dashboard (card artwork tiles, spend progress badges, card details panel)

## Test plan
- [ ] Dashboard renders populated state and empty state correctly
- [ ] No paywall overlay on dashboard
- [ ] Cards page shows portfolio view for authenticated users
- [ ] Card tiles have gradient artwork and status badges
- [ ] TypeScript: 0 new errors