### PR TITLE
feat(design): Financial Luminary fidelity sweep — all pages & AppShell

### DIFF
--- a/app/src/app/flights/page.tsx
+++ b/app/src/app/flights/page.tsx
@@ -130,7 +130,7 @@ export default function FlightsPage() {
   return (
     <AppShell>
       {/* ── Sticky header ── */}
-      <header className="sticky top-0 w-full z-40 bg-[#0f131f]/60 backdrop-blur-xl border-b border-white/5 h-20 flex items-center justify-between px-8">
+      <header className="sticky top-0 w-full z-40 bg-background/60 backdrop-blur-xl border-b border-white/5 h-20 flex items-center justify-between px-8">
         <div className="flex items-center gap-4">
           <h2 className="text-xl font-headline font-bold text-on-surface tracking-tight">Reward Flights</h2>
           <div className="h-4 w-[1px] bg-white/10 hidden md:block mx-2" />
@@ -140,7 +140,7 @@ export default function FlightsPage() {
         {totalPoints > 0 && (
           <div className="hidden md:flex items-center gap-6 text-right">
             <div>
-              <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-0.5">Total Points Pool</p>
+              <p className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest mb-0.5">Total Points Pool</p>
               <p className="text-lg font-headline font-bold text-on-surface tabular-nums">{totalPoints.toLocaleString()} pts</p>
             </div>
           </div>
@@ -152,10 +152,10 @@ export default function FlightsPage() {
         {/* ── Hero Search ── */}
         <div className="relative rounded-3xl overflow-hidden min-h-[380px] flex flex-col justify-end p-10 shadow-2xl border border-white/5">
           <div className="absolute inset-0 z-0">
-            <div className="absolute inset-0" style={{ background: 'linear-gradient(135deg, #1e2640 0%, #111827 60%, #0a0e1a 100%)' }} />
+            <div className="absolute inset-0 bg-surface-container-low" />
             <div className="absolute top-0 right-0 w-96 h-96 bg-primary/10 blur-[120px] rounded-full pointer-events-none" />
-            <div className="absolute bottom-0 left-1/3 w-64 h-64 bg-blue-500/5 blur-[100px] rounded-full pointer-events-none" />
-            <div className="absolute inset-0 bg-gradient-to-t from-[#0f131f]/80 via-[#0f131f]/40 to-transparent" />
+            <div className="absolute bottom-0 left-1/3 w-64 h-64 bg-tertiary/5 blur-[100px] rounded-full pointer-events-none" />
+            <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-background/40 to-transparent" />
           </div>
 
           <div className="relative z-10 w-full">
@@ -163,7 +163,7 @@ export default function FlightsPage() {
               <h3 className="text-5xl font-headline font-extrabold tracking-tight text-white mb-4 leading-tight">
                 Target Your Next Cabin.
               </h3>
-              <p className="text-slate-300 font-medium text-lg leading-relaxed">
+              <p className="text-on-surface font-medium text-lg leading-relaxed">
                 Instantly check reward availability across premium partner airlines and bridge the point gap.
               </p>
             </div>
@@ -179,48 +179,51 @@ export default function FlightsPage() {
                     <input
                       value={origin}
                       onChange={(e) => setOrigin(e.target.value)}
-                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-slate-600 focus:outline-none w-full truncate"
+                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-on-surface-variant/30 focus:outline-none w-full truncate"
                     />
                   </div>
                 </div>
                 {/* Destination */}
                 <div className="bg-surface-container/60 p-4 rounded-xl group hover:bg-surface-bright/80 transition-all cursor-pointer border border-white/5">
-                  <label className="block text-[10px] uppercase tracking-[0.15em] text-slate-400 font-bold mb-1.5">Destination</label>
+                  <label className="block text-[10px] uppercase tracking-[0.15em] text-on-surface-variant font-bold mb-1.5">Destination</label>
                   <div className="flex items-center gap-3">
-                    <PlaneLanding className="w-5 h-5 text-slate-500 shrink-0" />
+                    <PlaneLanding className="w-5 h-5 text-on-surface-variant shrink-0" />
                     <input
                       value={destination}
                       onChange={(e) => setDestination(e.target.value)}
-                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-slate-600 focus:outline-none w-full truncate"
+                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-on-surface-variant/30 focus:outline-none w-full truncate"
                     />
                   </div>
                 </div>
                 {/* Cabin Class */}
                 <div className="bg-surface-container/60 p-4 rounded-xl group hover:bg-surface-bright/80 transition-all cursor-pointer border border-white/5">
-                  <label className="block text-[10px] uppercase tracking-[0.15em] text-slate-400 font-bold mb-1.5">Cabin Class</label>
+                  <label className="block text-[10px] uppercase tracking-[0.15em] text-on-surface-variant font-bold mb-1.5">Cabin Class</label>
                   <div className="flex items-center gap-3">
-                    <Plane className="w-5 h-5 text-slate-500 shrink-0" />
+                    <Plane className="w-5 h-5 text-on-surface-variant shrink-0" />
                     <input
                       value={cabinClass}
                       onChange={(e) => setCabinClass(e.target.value)}
-                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-slate-600 focus:outline-none w-full truncate"
+                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-on-surface-variant/30 focus:outline-none w-full truncate"
                     />
                   </div>
                 </div>
                 {/* Departure */}
                 <div className="bg-surface-container/60 p-4 rounded-xl group hover:bg-surface-bright/80 transition-all cursor-pointer border border-white/5">
-                  <label className="block text-[10px] uppercase tracking-[0.15em] text-slate-400 font-bold mb-1.5">Departure</label>
+                  <label className="block text-[10px] uppercase tracking-[0.15em] text-on-surface-variant font-bold mb-1.5">Departure</label>
                   <div className="flex items-center gap-3">
-                    <span className="text-slate-500 text-lg shrink-0">📅</span>
+                    <span className="text-on-surface-variant text-lg shrink-0">📅</span>
                     <input
                       value={departure}
                       onChange={(e) => setDeparture(e.target.value)}
-                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-slate-600 focus:outline-none w-full truncate"
+                      className="bg-transparent font-bold text-on-surface text-lg placeholder:text-on-surface-variant/30 focus:outline-none w-full truncate"
                     />
                   </div>
                 </div>
               </div>
-              <button className="bg-primary text-[#003824] font-black px-12 rounded-xl hover:shadow-[0_0_20px_rgba(78,222,163,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all flex items-center justify-center gap-3 py-4 lg:py-0 whitespace-nowrap">
+              <button
+                className="text-on-primary font-black px-12 rounded-xl hover:opacity-90 hover:-translate-y-0.5 active:translate-y-0 transition-all flex items-center justify-center gap-3 py-4 lg:py-0 whitespace-nowrap"
+                style={{ background: 'var(--gradient-cta)' }}
+              >
                 <Search className="w-4 h-4" />
                 <span className="tracking-widest text-sm uppercase">Find Rewards</span>
               </button>
@@ -229,7 +232,7 @@ export default function FlightsPage() {
         </div>
 
         {/* ── Active Redemption Goal ── */}
-        <div className="bg-[#171b28]/80 rounded-3xl p-10 border border-white/5 relative overflow-hidden group shadow-xl">
+        <div className="bg-surface-container-low/80 rounded-3xl p-10 border border-white/5 relative overflow-hidden group shadow-xl">
           <div className="absolute right-0 top-0 h-full w-1/2 bg-gradient-to-l from-primary/10 to-transparent pointer-events-none" />
           <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-10 relative z-10">
             <div className="space-y-4">
@@ -243,7 +246,7 @@ export default function FlightsPage() {
               <h4 className="text-4xl font-headline font-extrabold tabular-nums tracking-tighter">
                 {goalPct}% to Business SYD → LHR
               </h4>
-              <p className="text-slate-400 max-w-lg text-lg leading-relaxed font-medium">
+              <p className="text-on-surface-variant max-w-lg text-lg leading-relaxed font-medium">
                 {pointsGap > 0
                   ? <>You&apos;re closing in on your goal. Secure <span className="text-white font-bold underline decoration-primary/40 underline-offset-4">{pointsGap.toLocaleString()} more points</span> to book via Qatar Airways.</>
                   : <>You have enough points to book this redemption. Book via <span className="text-white font-bold">Singapore Airlines</span> now.</>
@@ -253,7 +256,7 @@ export default function FlightsPage() {
             <div className="w-full lg:w-[420px] bg-background/40 p-8 rounded-2xl border border-white/5 backdrop-blur-md">
               <div className="flex justify-between items-end mb-4">
                 <div className="flex flex-col">
-                  <span className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-1">Current Points Pool</span>
+                  <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest mb-1">Current Points Pool</span>
                   <span className="text-xl font-bold text-white tracking-tight tabular-nums">
                     {currentPool > 0 ? currentPool.toLocaleString() : '121,500'} / {GOAL_POINTS.toLocaleString()}
                   </span>
@@ -275,19 +278,19 @@ export default function FlightsPage() {
                 <div className="mt-6 space-y-2">
                   {qffBalance > 0 && (
                     <div className="flex justify-between text-xs">
-                      <span className="text-slate-500 font-medium">Qantas FF</span>
+                      <span className="text-on-surface-variant font-medium">Qantas FF</span>
                       <span className="text-on-surface font-bold tabular-nums">{qffBalance.toLocaleString()} pts</span>
                     </div>
                   )}
                   {velocityBalance > 0 && (
                     <div className="flex justify-between text-xs">
-                      <span className="text-slate-500 font-medium">Velocity</span>
+                      <span className="text-on-surface-variant font-medium">Velocity</span>
                       <span className="text-on-surface font-bold tabular-nums">{velocityBalance.toLocaleString()} pts</span>
                     </div>
                   )}
                   {amexBalance > 0 && (
                     <div className="flex justify-between text-xs">
-                      <span className="text-slate-500 font-medium">Amex MR</span>
+                      <span className="text-on-surface-variant font-medium">Amex MR</span>
                       <span className="text-on-surface font-bold tabular-nums">{amexBalance.toLocaleString()} pts</span>
                     </div>
                   )}
@@ -302,13 +305,13 @@ export default function FlightsPage() {
           <div className="flex items-center justify-between mb-8">
             <div>
               <h3 className="text-3xl font-headline font-bold tracking-tight">Top Redemption Matches</h3>
-              <p className="text-slate-400 text-base font-medium mt-1">Real-time availability based on your point balance.</p>
+              <p className="text-on-surface-variant text-base font-medium mt-1">Real-time availability based on your point balance.</p>
             </div>
             <div className="hidden md:flex gap-3">
-              <button className="flex items-center gap-2 px-6 py-2.5 bg-surface-container-high/40 rounded-full text-xs font-bold text-slate-200 border border-white/10 hover:bg-surface-bright transition-all">
+              <button className="flex items-center gap-2 px-6 py-2.5 bg-surface-container-high/40 rounded-full text-xs font-bold text-on-surface border border-white/10 hover:bg-surface-bright transition-all">
                 Sort by Value
               </button>
-              <button className="flex items-center gap-2 px-6 py-2.5 bg-surface-container-high/40 rounded-full text-xs font-bold text-slate-200 border border-white/10 hover:bg-surface-bright transition-all">
+              <button className="flex items-center gap-2 px-6 py-2.5 bg-surface-container-high/40 rounded-full text-xs font-bold text-on-surface border border-white/10 hover:bg-surface-bright transition-all">
                 Filter Airlines
               </button>
             </div>
@@ -356,15 +359,15 @@ function AirlineRedemptionCard({ card }: { card: AirlineCard }) {
             <span className="text-4xl font-headline font-extrabold text-white tabular-nums tracking-tighter">
               {card.points.toLocaleString()}
             </span>
-            <span className={`text-[11px] font-bold uppercase ml-2 tracking-widest ${isEmiratesFirst ? 'text-[#c3c0ff]' : 'text-primary'}`}>
+            <span className={`text-[11px] font-bold uppercase ml-2 tracking-widest ${isEmiratesFirst ? 'text-tertiary' : 'text-primary'}`}>
               Points
             </span>
           </div>
           <span className={`px-3 py-1 text-[10px] font-black rounded border uppercase tracking-widest ${
             isSingapore
-              ? 'bg-primary text-[#003824] border-transparent'
+              ? 'bg-primary text-on-primary border-transparent'
               : isEmiratesFirst
-              ? 'bg-[#c3c0ff]/10 text-[#c3c0ff] border-[#c3c0ff]/20'
+              ? 'bg-tertiary/10 text-tertiary border-tertiary/20'
               : 'bg-white/10 backdrop-blur-md text-white border-white/20'
           }`}>
             {card.cabin}
@@ -376,24 +379,24 @@ function AirlineRedemptionCard({ card }: { card: AirlineCard }) {
       <div className="p-8 flex-1 flex flex-col">
         <div className="space-y-5 mb-8">
           <div className="flex justify-between items-center pb-3 border-b border-white/5">
-            <span className="text-sm font-semibold text-slate-400">Route Path</span>
+            <span className="text-sm font-semibold text-on-surface-variant">Route Path</span>
             <span className="text-sm font-bold text-on-surface tracking-tight">
               {card.route.split(' → ').map((seg, i, arr) => (
                 <span key={i}>
                   {seg}
                   {i < arr.length - 1 && (
-                    <span className={`mx-1 ${isEmiratesFirst ? 'text-[#c3c0ff]' : 'text-primary'}`}>→</span>
+                    <span className={`mx-1 ${isEmiratesFirst ? 'text-tertiary' : 'text-primary'}`}>→</span>
                   )}
                 </span>
               ))}
             </span>
           </div>
           <div className="flex justify-between items-center pb-3 border-b border-white/5">
-            <span className="text-sm font-semibold text-slate-400">Cabin Class</span>
+            <span className="text-sm font-semibold text-on-surface-variant">Cabin Class</span>
             <span className="text-sm font-bold text-on-surface">{card.cabinLabel}</span>
           </div>
           <div className="flex justify-between items-center">
-            <span className="text-sm font-semibold text-slate-400">Total Taxes</span>
+            <span className="text-sm font-semibold text-on-surface-variant">Total Taxes</span>
             <span className="text-sm font-bold text-on-surface tabular-nums">${card.taxes} AUD</span>
           </div>
         </div>
@@ -409,7 +412,10 @@ function AirlineRedemptionCard({ card }: { card: AirlineCard }) {
                   </span>
                 </div>
               </div>
-              <button className="w-full py-4 bg-gradient-to-br from-primary to-primary-container rounded-2xl text-sm font-black text-[#003824] hover:opacity-90 hover:scale-[1.02] active:scale-100 transition-all uppercase tracking-widest shadow-xl shadow-primary/20">
+              <button
+                className="w-full py-4 rounded-2xl text-sm font-black text-on-primary hover:opacity-90 hover:scale-[1.02] active:scale-100 transition-all uppercase tracking-widest shadow-xl shadow-primary/20"
+                style={{ background: 'var(--gradient-cta)' }}
+              >
                 Book with Points
               </button>
             </>
@@ -417,7 +423,7 @@ function AirlineRedemptionCard({ card }: { card: AirlineCard }) {
             <>
               <div className={`p-4 rounded-2xl border ${isEmiratesFirst ? 'bg-surface-container-highest/30 border-white/5' : 'bg-error/5 border-error/10'}`}>
                 <div className="flex justify-between items-center">
-                  <span className={`text-xs font-bold uppercase tracking-widest ${isEmiratesFirst ? 'text-slate-500' : 'text-error'}`}>
+                  <span className={`text-xs font-bold uppercase tracking-widest ${isEmiratesFirst ? 'text-on-surface-variant' : 'text-error'}`}>
                     Gap to target
                   </span>
                   <span className="text-lg font-extrabold text-white tabular-nums">
@@ -425,7 +431,7 @@ function AirlineRedemptionCard({ card }: { card: AirlineCard }) {
                   </span>
                 </div>
               </div>
-              <button className="w-full py-4 bg-white/5 hover:bg-white/10 border border-white/10 rounded-2xl text-sm font-bold text-slate-200 hover:text-white transition-all uppercase tracking-widest shadow-lg">
+              <button className="w-full py-4 bg-white/5 hover:bg-white/10 border border-white/10 rounded-2xl text-sm font-bold text-on-surface hover:text-white transition-all uppercase tracking-widest shadow-lg">
                 {isEmiratesFirst ? 'Analyze Transfers' : 'View Availability'}
               </button>
             </>

--- a/app/src/app/profit/page.tsx
+++ b/app/src/app/profit/page.tsx
@@ -246,9 +246,9 @@ export default function ProfitPage() {
   return (
     <AppShell>
       {/* ── Sticky header ── */}
-      <header className="sticky top-0 w-full z-40 bg-[#0f131f]/50 backdrop-blur-md border-b border-white/5">
+      <header className="sticky top-0 w-full z-40 bg-background/50 backdrop-blur-md border-b border-white/5">
         <div className="flex items-center justify-between px-6 h-16 w-full max-w-[1440px] mx-auto">
-          <h2 className="font-headline font-bold text-lg bg-gradient-to-br from-[#4edea3] to-[#10b981] bg-clip-text text-transparent">Profit Dashboard</h2>
+          <h2 className="font-headline font-bold text-lg bg-gradient-to-br from-primary to-primary-container bg-clip-text text-transparent">Profit Dashboard</h2>
         </div>
       </header>
 
@@ -329,7 +329,7 @@ export default function ProfitPage() {
                     </div>
                   )}
                 </div>
-                <p className="text-slate-500 text-sm mt-1">
+                <p className="text-on-surface-variant text-sm mt-1">
                   Across {fyCards.length} active card{fyCards.length !== 1 ? "s" : ""} this FY
                 </p>
               </section>
@@ -339,7 +339,7 @@ export default function ProfitPage() {
                 <section className="flex flex-col gap-5">
                   <div className="flex items-center justify-between">
                     <h3 className="text-xl font-headline font-bold">Monthly Yield</h3>
-                    <span className="px-3 py-1 bg-surface-container-highest/50 rounded-full text-[10px] font-extrabold text-slate-400 tracking-wider">
+                    <span className="px-3 py-1 bg-surface-container-highest/50 rounded-full text-[10px] font-extrabold text-on-surface-variant tracking-wider">
                       {chartData.length} MONTHS
                     </span>
                   </div>
@@ -362,7 +362,7 @@ export default function ProfitPage() {
                                   style={{ height: `${bonusPct * 66}%` }}
                                 />
                               </div>
-                              <span className={`text-[10px] font-bold ${isActive ? "text-primary" : "text-slate-500"}`}>
+                              <span className={`text-[10px] font-bold ${isActive ? "text-primary" : "text-on-surface-variant"}`}>
                                 {d.month.toUpperCase()}
                               </span>
                             </div>
@@ -377,22 +377,22 @@ export default function ProfitPage() {
               {/* Bento grid: Points Val / Fees / ROI */}
               <section className="grid grid-cols-2 gap-4">
                 <div className="col-span-1 p-6 rounded-2xl bg-surface-container/60 border border-white/5 flex flex-col gap-2">
-                  <span className="text-slate-400 text-[10px] font-bold tracking-widest uppercase">Points Val</span>
+                  <span className="text-on-surface-variant text-[10px] font-bold tracking-widest uppercase">Points Val</span>
                   <span className="text-2xl font-headline font-bold tabular-nums">{fmtAud(fyBonus)}</span>
                   <div className="mt-2 w-full h-1.5 bg-surface-container-highest rounded-full overflow-hidden">
                     <div className="bg-[#50e3c2] h-full" style={{ width: fyNet > 0 ? "66%" : "0%" }} />
                   </div>
                 </div>
                 <div className="col-span-1 p-6 rounded-2xl bg-surface-container/60 border border-white/5 flex flex-col gap-2">
-                  <span className="text-slate-400 text-[10px] font-bold tracking-widest uppercase">Fees Paid</span>
+                  <span className="text-on-surface-variant text-[10px] font-bold tracking-widest uppercase">Fees Paid</span>
                   <span className="text-2xl font-headline font-bold tabular-nums">{fmtAud(fyFees)}</span>
                   <div className="mt-2 w-full h-1.5 bg-surface-container-highest rounded-full overflow-hidden">
                     <div className="bg-secondary h-full" style={{ width: fyBonus > 0 ? `${Math.min((fyFees / fyBonus) * 100, 100)}%` : "0%" }} />
                   </div>
                 </div>
-                <div className="col-span-2 p-6 rounded-2xl bg-[#1b1f2c] border border-white/5 flex items-center justify-between">
+                <div className="col-span-2 p-6 rounded-2xl bg-surface-container border border-white/5 flex items-center justify-between">
                   <div className="flex flex-col gap-1">
-                    <span className="text-slate-400 text-[10px] font-bold tracking-widest uppercase">Average ROI</span>
+                    <span className="text-on-surface-variant text-[10px] font-bold tracking-widest uppercase">Average ROI</span>
                     <span className="text-3xl font-headline font-bold tabular-nums" style={{ color: "#50e3c2" }}>
                       {fyCards.length > 0
                         ? `${(fyCards.reduce((s, c) => s + c.bonusAud / Math.max(c.fee, 1), 0) / fyCards.length).toFixed(1)}x`
@@ -422,7 +422,7 @@ export default function ProfitPage() {
                                 <div className="w-10 h-6 bg-gradient-to-r from-[#d4af37] to-[#8b6b00] rounded-sm" />
                                 <div>
                                   <p className="text-[15px] font-bold font-headline">{c.name}</p>
-                                  <p className="text-[10px] text-slate-500 tracking-wide uppercase">{c.bank}</p>
+                                  <p className="text-[10px] text-on-surface-variant tracking-wide uppercase">{c.bank}</p>
                                 </div>
                               </div>
                               <div className="flex flex-col items-end">
@@ -438,7 +438,7 @@ export default function ProfitPage() {
                               </div>
                             </div>
                             <div className="space-y-2">
-                              <div className="flex justify-between text-[11px] font-bold text-slate-400">
+                              <div className="flex justify-between text-[11px] font-bold text-on-surface-variant">
                                 <span className="tracking-wide">ROI</span>
                                 <span className="tabular-nums">{roi.toFixed(1)}x return</span>
                               </div>

--- a/app/src/app/projections/page.tsx
+++ b/app/src/app/projections/page.tsx
@@ -247,7 +247,7 @@ export default function ProjectionsPage() {
           style={{ background: "rgba(23, 27, 40, 0.8)" }}
         >
           {/* Emerald glow on right */}
-          <div className="pointer-events-none absolute right-0 top-0 h-full w-1/2 bg-gradient-to-l from-[#4edea3]/8 to-transparent" />
+          <div className="pointer-events-none absolute right-0 top-0 h-full w-1/2 bg-gradient-to-l from-primary/8 to-transparent" />
 
           <div className="relative z-10 flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
             {/* Left: label + headline */}
@@ -281,7 +281,7 @@ export default function ProjectionsPage() {
                 ) : (
                   <>
                     You need{" "}
-                    <span className="font-bold text-white underline decoration-[#4edea3]/40 underline-offset-4">
+                    <span className="font-bold text-white underline decoration-primary/40 underline-offset-4">
                       {gap.toLocaleString()} more points
                     </span>{" "}
                     to book a{" "}
@@ -317,7 +317,7 @@ export default function ProjectionsPage() {
                 <span
                   className={`rounded-full border px-3 py-1 text-[10px] font-black uppercase tracking-widest ${
                     isSufficient
-                      ? "border-[#4edea3]/20 bg-primary/10 text-primary"
+                      ? "border-primary/20 bg-primary/10 text-primary"
                       : "border-white/10 bg-white/5 text-on-surface"
                   }`}
                 >
@@ -331,8 +331,7 @@ export default function ProjectionsPage() {
                   className="h-full rounded-full transition-all duration-1000 ease-out"
                   style={{
                     width: `${percentage}%`,
-                    background:
-                      "linear-gradient(to right, #4edea3, #6ffbbe, #10b981)",
+                    background: "var(--gradient-cta)",
                   }}
                 >
                   <div className="absolute right-0 top-0 h-full w-8 bg-gradient-to-r from-transparent to-white/20" />
@@ -415,14 +414,14 @@ export default function ProjectionsPage() {
                         style={{
                           background: `linear-gradient(135deg, ${
                             idx === 0
-                              ? "#003824, #005236"
+                              ? "var(--on-primary), color-mix(in srgb, var(--on-primary) 70%, transparent)"
                               : idx === 1
-                              ? "#1b1f2c, #262a37"
-                              : "#171b28, #1b1f2c"
+                              ? "var(--surface-container), var(--surface-container-high)"
+                              : "var(--surface-container-low), var(--surface-container)"
                           })`,
                         }}
                       />
-                      <div className="absolute inset-0 bg-gradient-to-t from-[#171b28] to-transparent" />
+                      <div className="absolute inset-0 bg-gradient-to-t from-surface-container-low to-transparent" />
 
                       {/* Airline label pill */}
                       <div
@@ -509,9 +508,10 @@ export default function ProjectionsPage() {
                           href="/cards"
                           className={`flex w-full items-center justify-center gap-2 rounded-2xl py-3.5 text-sm font-bold uppercase tracking-widest transition-all ${
                             isHighlighted
-                              ? "bg-gradient-to-br from-[#4edea3] to-[#10b981] text-on-primary shadow-lg shadow-[#4edea3]/20 hover:opacity-90 hover:scale-[1.02]"
+                              ? "text-on-primary shadow-lg shadow-primary/20 hover:opacity-90 hover:scale-[1.02]"
                               : "border border-white/10 bg-white/5 text-on-surface hover:bg-white/10 hover:text-on-surface"
                           }`}
+                          style={isHighlighted ? { background: "var(--gradient-cta)" } : undefined}
                         >
                           <CreditCard className="h-4 w-4" />
                           View Card Details

--- a/app/src/app/recommendations/page.tsx
+++ b/app/src/app/recommendations/page.tsx
@@ -30,10 +30,10 @@ const SORT_CHIPS: { value: SortType; label: string }[] = [
 ]
 
 const CARD_GRADIENTS = [
-  "from-[#1c2235] to-[#0a0e1a]",
-  "from-[#1a1f2c] to-[#252c3e]",
-  "from-[#0f131f] to-[#171b28]",
-  "from-[#141928] to-[#000000]",
+  "from-surface-container to-background",
+  "from-surface-container-high to-surface-container",
+  "from-background to-surface-container-low",
+  "from-surface-container-low to-background",
 ]
 
 function getBadgeLabel(index: number, rec: Recommendation): string {
@@ -310,13 +310,13 @@ export default function RecommendationsPage() {
                       {/* Fee + Status row */}
                       <div className="flex justify-between items-center mb-6 px-1">
                         <div>
-                          <p className="text-[10px] text-slate-500 uppercase tracking-widest">Annual Fee</p>
+                          <p className="text-[10px] text-on-surface-variant uppercase tracking-widest">Annual Fee</p>
                           <p className="text-sm font-bold tabular-nums">
                             {rec.card.annual_fee ? `$${rec.card.annual_fee}` : "$0"}
                           </p>
                         </div>
                         <div className="text-right">
-                          <p className="text-[10px] text-slate-500 uppercase tracking-widest">Status</p>
+                          <p className="text-[10px] text-on-surface-variant uppercase tracking-widest">Status</p>
                           <p className={`text-xs font-bold ${elig.color}`}>{elig.label}</p>
                         </div>
                       </div>

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -75,7 +75,7 @@ export default function SettingsPage() {
   return (
     <AppShell>
       {/* ── Sticky header ── */}
-      <header className="sticky top-0 w-full z-40 bg-[#0f131f]/50 backdrop-blur-md border-b border-white/5">
+      <header className="sticky top-0 w-full z-40 bg-background/50 backdrop-blur-md border-b border-white/5">
         <div className="flex items-center px-6 h-16 max-w-5xl mx-auto">
           <h2 className="font-headline font-bold text-lg bg-gradient-to-br from-primary to-primary-container bg-clip-text text-transparent">
             Account Settings

--- a/app/src/app/spending/page.tsx
+++ b/app/src/app/spending/page.tsx
@@ -217,7 +217,7 @@ function MobileSpendArc({
       {/* 2-col glass stat cards */}
       <div className="grid grid-cols-2 gap-4 max-w-sm mx-auto relative z-10">
         <div className="glass-card p-5 rounded-2xl text-left">
-          <p className="text-slate-400 text-xs font-semibold mb-2">Projected Points</p>
+          <p className="text-on-surface-variant text-xs font-semibold mb-2">Projected Points</p>
           <div className="flex items-baseline gap-1.5">
             <span className="text-on-surface font-bold text-2xl tabular-nums">
               {bonusPts ? `${(bonusPts / 1000).toFixed(0)}k` : "—"}
@@ -226,7 +226,7 @@ function MobileSpendArc({
           </div>
         </div>
         <div className="glass-card p-5 rounded-2xl text-left">
-          <p className="text-slate-400 text-xs font-semibold mb-2">Progress</p>
+          <p className="text-on-surface-variant text-xs font-semibold mb-2">Progress</p>
           <div className="flex items-baseline gap-1.5">
             <span className="text-on-surface font-bold text-2xl tabular-nums">
               {target > 0 ? `${Math.round(pct * 100)}%` : "—"}
@@ -399,9 +399,9 @@ export default function SpendingTrackerPage() {
   return (
     <AppShell>
       {/* ── Sticky header ── */}
-      <header className="sticky top-0 w-full z-40 bg-[#0f131f]/50 backdrop-blur-md border-b border-white/5">
+      <header className="sticky top-0 w-full z-40 bg-background/50 backdrop-blur-md border-b border-white/5">
         <div className="flex items-center justify-between px-10 h-16 w-full max-w-[1440px] mx-auto">
-          <h1 className="text-lg font-black bg-gradient-to-br from-[#4edea3] to-[#10b981] bg-clip-text text-transparent font-headline">Spend Tracker</h1>
+          <h1 className="text-lg font-black bg-gradient-to-br from-primary to-primary-container bg-clip-text text-transparent font-headline">Spend Tracker</h1>
           {/* Period selector chips */}
           <div className="flex items-center gap-1 bg-surface-container rounded-xl p-1">
             {(["monthly", "quarterly", "annual"] as SpendPeriod[]).map((p) => (
@@ -410,8 +410,8 @@ export default function SpendingTrackerPage() {
                 onClick={() => setPeriod(p)}
                 className={`px-3 py-1.5 rounded-lg text-[11px] font-bold uppercase tracking-wider transition-all ${
                   period === p
-                    ? "bg-primary text-[#003824] shadow-sm"
-                    : "text-slate-400 hover:text-on-surface hover:bg-white/5"
+                    ? "bg-primary text-on-primary shadow-sm"
+                    : "text-on-surface-variant hover:text-on-surface hover:bg-white/5"
                 }`}
               >
                 {p === "monthly" ? "Mo" : p === "quarterly" ? "Qtr" : "Ann"}
@@ -469,36 +469,36 @@ export default function SpendingTrackerPage() {
             <section className="max-w-[1440px] mx-auto">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                 <div className="glass-panel rounded-2xl p-6 flex flex-col gap-3 group transition-all hover:bg-white/[0.05]">
-                  <span className="text-slate-500 text-[10px] font-bold uppercase tracking-[0.2em]">Est. Rewards</span>
+                  <span className="text-on-surface-variant text-[10px] font-bold uppercase tracking-[0.2em]">Est. Rewards</span>
                   <div className="flex items-baseline gap-2">
                     <span className="text-3xl font-headline font-bold text-tertiary tabular-nums tracking-tighter">
                       {bonusPts ? `${(bonusPts / 1000).toFixed(0)}k` : "—"}
                     </span>
-                    <span className="text-slate-500 text-[10px] uppercase font-bold tracking-widest">
+                    <span className="text-on-surface-variant text-[10px] uppercase font-bold tracking-widest">
                       {bonusPts ? "pts" : "if target hit"}
                     </span>
                   </div>
                 </div>
                 <div className="glass-panel rounded-2xl p-6 flex flex-col gap-3 group transition-all hover:bg-white/[0.05]">
-                  <span className="text-slate-500 text-[10px] font-bold uppercase tracking-[0.2em]">Time Remaining</span>
+                  <span className="text-on-surface-variant text-[10px] font-bold uppercase tracking-[0.2em]">Time Remaining</span>
                   <div className="flex items-baseline gap-2">
                     <span className="text-3xl font-headline font-bold text-white tabular-nums tracking-tighter">
                       {daysLeft !== null ? daysLeft : "—"}
                     </span>
-                    <span className="text-slate-500 text-[10px] uppercase font-bold tracking-widest">Days</span>
+                    <span className="text-on-surface-variant text-[10px] uppercase font-bold tracking-widest">Days</span>
                   </div>
                 </div>
                 <div className="glass-panel rounded-2xl p-6 flex flex-col gap-3 group transition-all hover:bg-white/[0.05]">
-                  <span className="text-slate-500 text-[10px] font-bold uppercase tracking-[0.2em]">Daily Pace</span>
+                  <span className="text-on-surface-variant text-[10px] font-bold uppercase tracking-[0.2em]">Daily Pace</span>
                   <div className="flex items-baseline gap-2">
                     <span className="text-3xl font-headline font-bold text-white tabular-nums tracking-tighter">
                       {dailyPace !== null ? `$${Math.ceil(dailyPace)}` : "—"}
                     </span>
-                    <span className="text-slate-500 text-[10px] uppercase font-bold tracking-widest">/day</span>
+                    <span className="text-on-surface-variant text-[10px] uppercase font-bold tracking-widest">/day</span>
                   </div>
                 </div>
                 <div className="glass-panel rounded-2xl p-6 flex flex-col gap-3 group transition-all hover:bg-white/[0.05]">
-                  <span className="text-slate-500 text-[10px] font-bold uppercase tracking-[0.2em]">Bonus Progress</span>
+                  <span className="text-on-surface-variant text-[10px] font-bold uppercase tracking-[0.2em]">Bonus Progress</span>
                   <div className="flex items-baseline gap-2">
                     <span className="text-3xl font-headline font-bold text-white tabular-nums tracking-tighter">{pct}%</span>
                   </div>
@@ -568,7 +568,7 @@ export default function SpendingTrackerPage() {
                   <div className="bg-surface-container-low rounded-2xl p-10 relative overflow-hidden flex flex-col items-center text-center border border-white/5 h-full">
                     <div className="absolute -top-24 -left-24 w-64 h-64 bg-primary/10 blur-[100px] rounded-full" />
                     <div className="relative w-full">
-                      <h2 className="text-slate-500 text-[11px] uppercase tracking-[0.2em] font-bold mb-10">
+                      <h2 className="text-on-surface-variant text-[11px] uppercase tracking-[0.2em] font-bold mb-10">
                         {activeCard.card.bank} {activeCard.card.name} Bonus Progress
                       </h2>
 
@@ -622,7 +622,7 @@ export default function SpendingTrackerPage() {
                           <span className="text-5xl font-headline font-extrabold tabular-nums tracking-tight text-white">
                             {formatCurrencyCompact(activeCard.current_spend)}
                           </span>
-                          <span className="text-slate-500 text-[10px] uppercase tracking-[0.15em] font-bold mt-2">
+                          <span className="text-on-surface-variant text-[10px] uppercase tracking-[0.15em] font-bold mt-2">
                             of {formatCurrencyCompact(activeCard.spend_target)} Goal
                           </span>
                         </div>
@@ -640,7 +640,7 @@ export default function SpendingTrackerPage() {
                         if (daysLeft <= 0) return null
                         const dailyAmt = (activeCard.spend_target - activeCard.current_spend) / daysLeft
                         return (
-                          <p className="text-slate-400 text-sm max-w-[300px] leading-relaxed">
+                          <p className="text-on-surface-variant text-sm max-w-[300px] leading-relaxed">
                             Spend{" "}
                             <span className="text-on-surface font-semibold tabular-nums">
                               {formatCurrency(dailyAmt)}
@@ -660,7 +660,7 @@ export default function SpendingTrackerPage() {
                   <div className="flex items-center justify-between mb-8">
                     <div>
                       <h3 className="text-2xl font-headline font-bold tracking-tight">Recent Activity</h3>
-                      <p className="text-slate-500 text-sm mt-1.5 font-medium">
+                      <p className="text-on-surface-variant text-sm mt-1.5 font-medium">
                         Spend transactions for {activeCard.card.bank} {activeCard.card.name}
                       </p>
                     </div>
@@ -757,7 +757,7 @@ export default function SpendingTrackerPage() {
                               </div>
                               <div>
                                 <h4 className="font-bold text-on-surface text-base">{txn.description}</h4>
-                                <p className="text-slate-500 text-xs mt-0.5 font-medium">{txn.category}</p>
+                                <p className="text-on-surface-variant text-xs mt-0.5 font-medium">{txn.category}</p>
                               </div>
                             </div>
                             <div className="text-right">
@@ -772,13 +772,13 @@ export default function SpendingTrackerPage() {
                           </div>
                         ))
                       ) : (
-                        <div className="p-6 text-center text-slate-500 text-sm">
+                        <div className="p-6 text-center text-on-surface-variant text-sm">
                           No transactions yet. Add one to start tracking.
                         </div>
                       )}
                     </div>
                     <div className="p-5 bg-surface-container-high/30 border-t border-white/5 flex justify-center">
-                      <button className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 hover:text-primary transition-colors py-2 px-8">
+                      <button className="text-xs font-bold uppercase tracking-[0.2em] text-on-surface-variant hover:text-primary transition-colors py-2 px-8">
                         Load More Activity
                       </button>
                     </div>
@@ -799,18 +799,18 @@ export default function SpendingTrackerPage() {
                 return (
                   <section className="-mx-4 px-4 -mt-10 grid grid-cols-2 gap-5">
                     <div className="bg-surface-container/80 backdrop-blur-md p-6 rounded-2xl border border-white/5 shadow-xl transition-transform active:scale-95">
-                      <p className="text-slate-400 text-[10px] font-bold uppercase tracking-[0.15em] mb-1.5">Spend Progress</p>
+                      <p className="text-on-surface-variant text-[10px] font-bold uppercase tracking-[0.15em] mb-1.5">Spend Progress</p>
                       <p className="text-2xl font-bold font-headline tabular-nums">{formatCurrencyCompact(activeCard.current_spend)}</p>
-                      <p className="text-slate-500 text-xs mt-1">of {formatCurrencyCompact(activeCard.spend_target)} goal</p>
+                      <p className="text-on-surface-variant text-xs mt-1">of {formatCurrencyCompact(activeCard.spend_target)} goal</p>
                     </div>
                     <div className="bg-surface-container/80 backdrop-blur-md p-6 rounded-2xl border border-white/5 shadow-xl transition-transform active:scale-95">
-                      <p className="text-slate-400 text-[10px] font-bold uppercase tracking-[0.15em] mb-1.5">
+                      <p className="text-on-surface-variant text-[10px] font-bold uppercase tracking-[0.15em] mb-1.5">
                         {daysLeft !== null ? "Days Left" : "Daily Pace"}
                       </p>
                       <p className="text-2xl font-bold font-headline tabular-nums">
                         {daysLeft !== null ? daysLeft : dailyPaceMobile !== null ? `$${Math.ceil(dailyPaceMobile)}` : "—"}
                       </p>
-                      <p className="text-slate-500 text-xs mt-1">
+                      <p className="text-on-surface-variant text-xs mt-1">
                         {daysLeft !== null ? "until deadline" : "per day needed"}
                       </p>
                     </div>
@@ -823,7 +823,7 @@ export default function SpendingTrackerPage() {
                 <div className="flex items-center justify-between mb-8 px-1">
                   <div>
                     <h3 className="text-2xl font-bold font-headline tracking-tight">Recent Activity</h3>
-                    <p className="text-slate-500 text-xs mt-1">Spend tracking for {activeCard.card.name}</p>
+                    <p className="text-on-surface-variant text-xs mt-1">Spend tracking for {activeCard.card.name}</p>
                   </div>
                   <button
                     onClick={() => setIsDialogOpen(true)}
@@ -847,7 +847,7 @@ export default function SpendingTrackerPage() {
                           </div>
                           <div>
                             <p className="font-bold text-on-surface text-base leading-tight">{txn.description}</p>
-                            <p className="text-slate-500 text-xs mt-0.5">{txn.category}</p>
+                            <p className="text-on-surface-variant text-xs mt-0.5">{txn.category}</p>
                           </div>
                         </div>
                         <div className="text-right">
@@ -861,7 +861,7 @@ export default function SpendingTrackerPage() {
                     ))
                   ) : (
                     <div className="p-8 text-center rounded-2xl bg-surface-container/30 border border-white/5">
-                      <p className="text-slate-500 text-sm">No transactions recorded yet.</p>
+                      <p className="text-on-surface-variant text-sm">No transactions recorded yet.</p>
                       <button
                         onClick={() => setIsDialogOpen(true)}
                         className="mt-3 text-primary text-sm font-bold bg-primary/10 px-4 py-2 rounded-full hover:bg-primary/20 transition-colors"
@@ -883,10 +883,10 @@ export default function SpendingTrackerPage() {
           onClick={() => setIsDialogOpen(true)}
           className="fixed bottom-28 right-6 w-16 h-16 rounded-2xl z-50 flex items-center justify-center active:scale-90 transition-all md:hidden overflow-hidden"
           style={{
-            background: "linear-gradient(135deg, #4edea3 0%, #10b981 100%)",
+            background: "var(--gradient-cta)",
             boxShadow: "0 12px 40px rgba(78,222,163,0.4)",
             border: "1px solid rgba(255,255,255,0.2)",
-            color: "#003824",
+            color: "var(--on-primary)",
           }}
         >
           <span className="text-3xl font-bold leading-none">+</span>

--- a/app/src/components/forms/BetaRequestForm.tsx
+++ b/app/src/components/forms/BetaRequestForm.tsx
@@ -85,7 +85,7 @@ export function BetaRequestForm({
           onChange={(e) => setEmail(e.target.value)}
           required
           placeholder="you@example.com"
-          className="mt-2 w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-white placeholder-slate-400 backdrop-blur-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+          className="mt-2 w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-white placeholder-on-surface-variant backdrop-blur-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
         />
       </div>
 
@@ -99,7 +99,7 @@ export function BetaRequestForm({
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Your name"
-          className="mt-2 w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-white placeholder-slate-400 backdrop-blur-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+          className="mt-2 w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-white placeholder-on-surface-variant backdrop-blur-sm transition-colors focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
         />
       </div>
 

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -55,12 +55,12 @@ export function AppShell({ children }: AppShellProps) {
   return (
     <div className="min-h-screen overflow-x-hidden" style={{ background: "var(--surface)" }}>
       {/* ── Desktop fixed sidebar ── */}
-      <aside className="hidden md:flex fixed left-0 top-0 h-screen w-64 bg-[#171b28] z-40 flex-col overflow-y-auto font-['Plus_Jakarta_Sans'] antialiased tracking-tight">
+      <aside className="hidden md:flex fixed left-0 top-0 h-screen w-64 bg-surface-container-low z-40 flex-col overflow-y-auto font-headline antialiased tracking-tight">
         <div className="p-8 flex flex-col h-full">
           {/* Logo */}
           <div className="mb-10">
-            <h1 className="text-xl font-bold tracking-tighter text-[#4edea3]">Reward Relay</h1>
-            <p className="text-[10px] uppercase tracking-widest text-slate-500 mt-1">The Financial Luminary</p>
+            <h1 className="text-xl font-bold tracking-tighter text-primary">Reward Relay</h1>
+            <p className="text-[10px] uppercase tracking-widest text-on-surface-variant mt-1">The Financial Luminary</p>
           </div>
 
           {/* Nav */}
@@ -74,7 +74,7 @@ export function AppShell({ children }: AppShellProps) {
                   className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-all ${
                     active
                       ? "bg-surface-container text-primary rounded-lg"
-                      : "text-slate-400 hover:bg-surface-container-highest hover:text-on-surface rounded-lg"
+                      : "text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface rounded-lg"
                   }`}
                 >
                   <Icon className="h-4 w-4 flex-shrink-0" />
@@ -86,10 +86,11 @@ export function AppShell({ children }: AppShellProps) {
 
           {/* Sidebar footer */}
           <div className="mt-auto p-4">
-            <p className="text-[10px] uppercase tracking-widest text-slate-500 mb-3">The Financial Luminary</p>
+            <p className="text-[10px] uppercase tracking-widest text-on-surface-variant mb-3">The Financial Luminary</p>
             <Link
               href="/cards"
-              className="block bg-gradient-to-r from-[#4edea3] to-[#10b981] text-black rounded-full px-4 py-2 text-sm font-semibold w-full text-center"
+              className="block text-on-primary rounded-full px-4 py-2 text-sm font-semibold w-full text-center"
+              style={{ background: "var(--gradient-cta)" }}
             >
               Add New Card
             </Link>
@@ -102,7 +103,7 @@ export function AppShell({ children }: AppShellProps) {
                 </div>
                 <div className="flex flex-col min-w-0">
                   <span className="text-sm font-bold text-on-surface truncate">{userEmail.split("@")[0]}</span>
-                  <span className="text-xs text-slate-500">Elite Tier</span>
+                  <span className="text-xs text-on-surface-variant">Elite Tier</span>
                 </div>
               </div>
             )}
@@ -111,7 +112,7 @@ export function AppShell({ children }: AppShellProps) {
             <button
               onClick={handleSignOut}
               disabled={signingOut}
-              className="mt-4 flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-lg transition-colors hover:bg-white/5 disabled:opacity-50 text-slate-500"
+              className="mt-4 flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-lg transition-colors hover:bg-white/5 disabled:opacity-50 text-on-surface-variant"
             >
               <LogOut className="h-4 w-4 flex-shrink-0" />
               {signingOut ? "Signing out…" : "Sign out"}
@@ -124,7 +125,7 @@ export function AppShell({ children }: AppShellProps) {
       <header
         className="sticky top-0 z-20 flex items-center justify-between px-4 py-3 md:hidden"
         style={{
-          background: "rgba(23,27,40,0.95)",
+          background: "color-mix(in srgb, var(--surface-container-low) 95%, transparent)",
           backdropFilter: "blur(12px)",
           borderBottom: "1px solid rgba(255,255,255,0.05)",
         }}


### PR DESCRIPTION
## Summary

- Replaced all remaining hardcoded hex values (`#0f131f`, `#171b28`, `#4edea3`, `#10b981`, `#003824`, `#c3c0ff`, `#1b1f2c`) with Financial Luminary design tokens across **flights**, **spending**, **profit**, **projections**, **recommendations**, **settings** pages plus **AppShell** and **BetaRequestForm**
- All `text-slate-*` utility classes replaced with `text-on-surface` / `text-on-surface-variant` tokens
- All primary CTA buttons now use `style={{ background: "var(--gradient-cta)" }}` inline style for correct gradient rendering
- AppShell sidebar: `bg-[#171b28]` → `bg-surface-container-low`, `font-['Plus_Jakarta_Sans']` → `font-headline`, Add New Card uses gradient CTA
- Hero backgrounds: hardcoded inline gradient hex → `bg-surface-container-low` + `bg-background` tokens
- SVG `stopColor`/`stroke`/`fill` attrs intentionally preserved (CSS vars not supported as SVG presentation attrs)

## Test plan

- [ ] Verify sidebar renders with correct dark surface on desktop
- [ ] Verify flights page hero, redemption goal section, and airline cards render without hex colours
- [ ] Verify all CTAs show gradient background (Find Rewards, Book with Points, Add New Card)
- [ ] Verify spending/profit/projections/recommendations pages render with token colours
- [ ] Confirm no visual regressions in dark mode palette