### PR TITLE
feat(recommendations): grayscale on non-best-match card visuals

### DIFF
--- a/app/src/app/recommendations/page.tsx
+++ b/app/src/app/recommendations/page.tsx
@@ -258,7 +258,7 @@ export default function RecommendationsPage() {
 
                     {/* Card visual */}
                     <div
-                      className={`aspect-[1.58/1] w-full mb-6 rounded-xl overflow-hidden bg-gradient-to-br ${gradient} p-4 flex flex-col justify-between relative shadow-xl`}
+                      className={`aspect-[1.58/1] w-full mb-6 rounded-xl overflow-hidden bg-gradient-to-br ${gradient} p-4 flex flex-col justify-between relative shadow-xl transition-all duration-300 ${!isBestMatch ? "grayscale opacity-70 group-hover:grayscale-0 group-hover:opacity-100" : ""}`}
                     >
                       <div className="absolute inset-0 bg-gradient-to-tr from-black/40 to-transparent" />
                       <div className="relative z-10 flex justify-between items-start">


### PR DESCRIPTION
## Summary
- Apply `grayscale opacity-70` to non-best-match card visual thumbnails, matching the Financial Luminary design spec
- On hover, the card visual transitions back to full colour (`grayscale-0 opacity-100`) for interactive feedback
- Uses `transition-all duration-300` for smooth reveal, consistent with the group-hover pattern in the rest of the design

## Test plan
- [ ] Best Match card visual renders at full colour with primary glow
- [ ] All other card visuals render at grayscale/70% opacity by default
- [ ] Hovering a non-best-match card reveals the full colour visual
- [ ] TypeScript build passes