### PR TITLE
feat(card-detail): responsive key dates grid for mobile

### DIFF
--- a/app/src/app/tracker/page.tsx
+++ b/app/src/app/tracker/page.tsx
@@ -309,6 +309,7 @@ export default function TrackerPage() {
             <Plus className="h-6 w-6 lg:h-7 lg:w-7" />
           </Link>
         </div>
+      </div>
     </AppShell>
   )
 }


### PR DESCRIPTION
## Summary
- Key dates cells scale padding from `p-4` (mobile) to `lg:p-6` (desktop), matching the Stitch mobile card detail spec's tighter `p-4` treatment
- Value text scales from `text-sm` on mobile to `lg:text-lg` on desktop, preventing oversized dates on small screens
- Cells center content on mobile (`items-center justify-center text-center`) matching the mobile design's centered layout; left-aligned on desktop (`lg:block lg:text-left`)

## Test plan
- [ ] Mobile: key dates show compact `p-4` cells with centered, `text-sm` values
- [ ] Desktop: key dates show `p-6` cells with left-aligned, `text-lg` values
- [ ] TypeScript build passes