### PR TITLE
fix(layout): restore marketing header on terms/privacy pages

### DIFF
--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -1,6 +1,9 @@
+import Header from "@/components/layout/Header"
+
 export default function PrivacyPolicy() {
   return (
     <div className="min-h-screen bg-[var(--surface-muted)] text-white">
+      <Header logoClickable />
       <div className="mx-auto max-w-4xl px-6 py-12">
         <div className="space-y-8">
           <div className="space-y-4">

--- a/app/src/app/terms/page.tsx
+++ b/app/src/app/terms/page.tsx
@@ -1,6 +1,9 @@
+import Header from "@/components/layout/Header"
+
 export default function TermsOfService() {
   return (
     <div className="min-h-screen bg-[var(--surface-muted)] text-white">
+      <Header logoClickable />
       <div className="mx-auto max-w-4xl px-6 py-12">
         <div className="space-y-8">
           <div className="space-y-4">


### PR DESCRIPTION
## Problem

The Terms of Service and Privacy Policy pages were missing the marketing header (Login/Sign Up buttons) that appears on the landing page `/`.

## Root cause

Both `terms/page.tsx` and `privacy/page.tsx` rendered their content directly inside a plain `<div>` wrapper without importing or rendering the shared `Header` component. The landing page renders `<Header logoClickable={false} />` inline in its JSX — there is no shared layout wrapping these routes, so ToS/Privacy pages simply had no header at all.

## Fix

Added `import Header from "@/components/layout/Header"` and rendered `<Header logoClickable />` at the top of both pages. `logoClickable` is set to `true` so the logo navigates back to home (appropriate for inner pages).

## Files changed

- `app/src/app/terms/page.tsx`
- `app/src/app/privacy/page.tsx`