### PR TITLE
fix(design-system): reduce base font scale 16px → 14px

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -139,7 +139,7 @@
   }
 
   html {
-    /* Smooth color transitions when theme changes */
+    font-size: 14px; /* Design system base: scales all rem values ~12.5% smaller than browser default */
     color-scheme: light dark;
   }
 


### PR DESCRIPTION
## What

Sets `html { font-size: 14px }` in `globals.css`.

## Why this approach

All Tailwind utilities (`text-sm`, `text-xl`, `p-4`, `rounded-lg`, etc.) are defined in `rem`. Setting the HTML root font-size is the single design-system-level knob — everything scales proportionally without touching individual components. 14px vs 16px = ~12.5% reduction across all type and spacing.

## Screenshots

### Landing
![landing](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/landing-stitch.png)

### Login
![login](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/login-stitch.png)

### Dashboard
![dashboard](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/dashboard-stitch.png)

### Cards
![cards](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/cards-stitch.png)

### Tracker
![tracker](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/tracker-stitch.png)

### Spending
![spending](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/spending-stitch.png)

### Flights
![flights](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/flights-stitch.png)

### Profit
![profit](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/profit-stitch.png)

### Settings
![settings](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-base-font-scale/settings-stitch.png)