### PR TITLE
fix(dashboard): welcome toast once per session; move page padding to AppShell

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -72,8 +72,10 @@ export default function DashboardPage() {
       const {
         data: { session },
       } = await supabase.auth.getSession()
-      const isNewLogin = !!(session && !email)
-      loadCards(isNewLogin)
+      const alreadyWelcomed = sessionStorage.getItem('rr_welcomed') === '1'
+      const shouldWelcome = !!session && !alreadyWelcomed
+      if (shouldWelcome) sessionStorage.setItem('rr_welcomed', '1')
+      loadCards(shouldWelcome)
     }
     checkAndLoad()
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -73,7 +73,7 @@ export default function SettingsPage() {
 
   return (
     <AppShell>
-      <div className="max-w-7xl mx-auto px-6 md:px-12 pt-8 pb-16">
+      <div className="max-w-7xl mx-auto pb-16">
         <div className="mb-12">
           <h1 className="text-3xl md:text-[3.5rem] font-extrabold font-headline leading-tight tracking-tight text-on-surface">
             Account Settings

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -191,7 +191,7 @@ export function AppShell({ children }: AppShellProps) {
 
       {/* Page content */}
       <div className="pt-16 md:pl-64 pb-24 md:pb-6 min-w-0">
-        <main className="min-w-0 overflow-x-hidden">{children}</main>
+        <main className="min-w-0 overflow-x-hidden px-6 md:px-10 py-8">{children}</main>
       </div>
 
       {/* Mobile bottom nav */}


### PR DESCRIPTION
## Changes

- **Welcome toast**: Replace broken `isNewLogin` logic (email always null on mount) with `sessionStorage` — toast fires once per browser session, not on every page load
- **AppShell padding**: Add `px-6 md:px-10 py-8` to `<main>` in AppShell so all pages inherit consistent spacing
- **Settings page**: Remove now-duplicate `px-6 md:px-12 pt-8` from outermost wrapper div

## Files changed
- `app/src/app/dashboard/page.tsx` — sessionStorage welcome guard
- `app/src/components/layout/AppShell.tsx` — padding on `<main>`
- `app/src/app/settings/page.tsx` — remove duplicate horizontal/top padding

## Screenshots

### Landing
![landing](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/landing-stitch.png)

### Login
![login](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/login-stitch.png)

### Dashboard
![dashboard](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/dashboard-stitch.png)

### Cards
![cards](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/cards-stitch.png)

### Tracker
![tracker](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/tracker-stitch.png)

### Spending
![spending](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/spending-stitch.png)

### Flights
![flights](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/flights-stitch.png)

### Profit
![profit](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/profit-stitch.png)

### Settings
![settings](https://raw.githubusercontent.com/johankaito/reward-relay/d8a33f679df98e7691e3f796e86ddb5fa301c6ac/screenshots/fix-dashboard-padding-and-welcome/settings-stitch.png)