### PR TITLE
fix(mobile-nav): pb-safe for iPhone home indicator + active tap feedback

### DIFF
--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -204,14 +204,14 @@ export function AppShell({ children }: AppShellProps) {
           boxShadow: "0 -8px 32px rgba(0,0,0,0.5)",
         }}
       >
-        <div className="grid grid-cols-5 h-20" style={{ minHeight: 80 }}>
+        <div className="grid grid-cols-5 pb-safe" style={{ minHeight: 80 }}>
           {navItems.map(({ href, label, materialIcon }) => {
             const active = isActive(href)
             return (
               <button
                 key={href}
                 onClick={() => router.push(href)}
-                className={`flex flex-col items-center justify-center gap-1 py-2 px-1 transition-colors active:opacity-80 ${
+                className={`flex flex-col items-center justify-center gap-1 py-2 px-1 transition-colors active:bg-white/5 ${
                   active ? "text-[#4edea3]" : "text-slate-500"
                 }`}
               >


### PR DESCRIPTION
## Summary

Two missing polish items from [MOBILE-001] in the gap analysis:

- **`pb-safe`** on the bottom nav grid — without this, the nav items sit flush against the bottom on iPhones with a home indicator bar (the last 34px is unusable). Replaced `h-20` fixed height with `pb-safe` so the grid expands to accommodate the safe area inset.
- **`active:bg-white/5`** on each nav button — replaces `active:opacity-80` with a subtle background flash on tap, matching the design spec's touch feedback pattern.

## Test plan

- [ ] iPhone (real device or Safari responsive): bottom nav items are not clipped by home indicator
- [ ] Tapping any nav item shows a brief `rgba(255,255,255,0.05)` flash
- [ ] Desktop: no visual change (nav is hidden at `md+`)

## Visual Review

> Screenshots taken at 390×844 (iPhone 14) on branch `fix/mobile-nav-safe-area`
> No Stitch mobile export available for these pages — live implementation shown.

### dashboard (mobile)

| Live implementation |
|---|
| ![dashboard-mobile-live](https://raw.githubusercontent.com/johankaito/reward-relay/b039c13390c5f3ba075cfe3519e5b29f8f377bd6/screenshots/fix-mobile-nav-safe-area/dashboard-mobile-live.png) |

### cards (mobile)

| Live implementation |
|---|
| ![cards-mobile-live](https://raw.githubusercontent.com/johankaito/reward-relay/b039c13390c5f3ba075cfe3519e5b29f8f377bd6/screenshots/fix-mobile-nav-safe-area/cards-mobile-live.png) |

---
⚠️ **Needs human review before merge** — do not auto-merge this PR