### PR TITLE
fix(tiers): protection features ungated — reminders free for all

### DIFF
--- a/app/src/app/api/reminders/check/route.ts
+++ b/app/src/app/api/reminders/check/route.ts
@@ -5,6 +5,8 @@ import {
   get30DayReminderEmail,
   get14DayReminderEmail,
   get7DayReminderEmail,
+  getAnnualFee30DayReminderEmail,
+  getAnnualFee14DayReminderEmail,
 } from "@/lib/email/templates";
 
 // Force dynamic rendering to avoid build-time evaluation
@@ -27,9 +29,11 @@ export async function GET(request: Request) {
       "30_day": 0,
       "14_day": 0,
       "7_day": 0,
+      "annual_fee_30d": 0,
+      "annual_fee_14d": 0,
     };
 
-    // Get all active user cards
+    // ── Cancellation reminders (all tiers) ──────────────────────────────────
     const { data: cards, error } = await supabaseAdmin
       .from("user_cards")
       .select(`
@@ -86,16 +90,8 @@ export async function GET(request: Request) {
 
       if (!userData?.user?.email) continue;
 
-      // Tier gating: free users only receive the 7-day reminder
+      // User preference opt-out (tier check removed — all users get 30/14/7 cadence)
       const meta = (userData.user.user_metadata ?? {}) as Record<string, unknown>;
-      const isPro =
-        meta.subscription_tier === "pro" ||
-        meta.subscription_tier === "business" ||
-        meta.is_pro === true;
-
-      if (!isPro && reminderType !== "7_day") continue;
-
-      // User preference opt-out
       const prefKey =
         reminderType === "30_day"
           ? "reminder_30d"
@@ -142,6 +138,117 @@ export async function GET(request: Request) {
         })
         .catch((error) => {
           console.error(`Failed to send ${reminderType} reminder:`, error);
+        });
+
+      promises.push(sendPromise);
+    }
+
+    // ── Annual fee renewal reminders (all tiers) ────────────────────────────
+    const { data: annualFeeCards, error: annualFeeError } = await supabaseAdmin
+      .from("user_cards")
+      .select(`
+        *,
+        card:cards(*)
+      `)
+      .eq("status", "active")
+      .not("application_date", "is", null);
+
+    if (annualFeeError) throw annualFeeError;
+
+    for (const userCard of annualFeeCards || []) {
+      if (!userCard.application_date) continue;
+
+      // Resolve annual fee: user_cards override takes precedence, then catalog
+      const annualFee: number =
+        (userCard.annual_fee ?? userCard.card?.annual_fee ?? 0) as number;
+      if (annualFee <= 0) continue;
+
+      // Renewal date = application_date + 12 months (anniversary)
+      const applicationDate = new Date(userCard.application_date);
+      const renewalDate = new Date(applicationDate);
+      renewalDate.setFullYear(renewalDate.getFullYear() + 1);
+
+      // Advance renewal year until it's in the future
+      while (renewalDate < today) {
+        renewalDate.setFullYear(renewalDate.getFullYear() + 1);
+      }
+
+      const daysUntilRenewal = Math.ceil(
+        (renewalDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+      );
+
+      let annualFeeReminderType: "annual_fee_30d" | "annual_fee_14d" | null = null;
+      let annualFeeTemplate:
+        | typeof getAnnualFee30DayReminderEmail
+        | typeof getAnnualFee14DayReminderEmail
+        | null = null;
+
+      if (daysUntilRenewal <= 14 && daysUntilRenewal > 0) {
+        annualFeeReminderType = "annual_fee_14d";
+        annualFeeTemplate = getAnnualFee14DayReminderEmail;
+      } else if (daysUntilRenewal <= 30 && daysUntilRenewal > 14) {
+        annualFeeReminderType = "annual_fee_30d";
+        annualFeeTemplate = getAnnualFee30DayReminderEmail;
+      }
+
+      if (!annualFeeReminderType || !annualFeeTemplate) continue;
+
+      // Check if reminder already sent for this renewal cycle
+      // Use the renewal year as part of the check to allow re-sending next year
+      const renewalYear = renewalDate.getFullYear();
+      const { data: existingAnnualReminder } = await supabaseAdmin
+        .from("email_reminders")
+        .select("id")
+        .eq("user_card_id", userCard.id)
+        .eq("reminder_type", `${annualFeeReminderType}_${renewalYear}`)
+        .single();
+
+      if (existingAnnualReminder) continue; // Already sent for this cycle
+
+      // Get user email
+      const { data: userData } = await supabaseAdmin.auth.admin.getUserById(
+        userCard.user_id
+      );
+
+      if (!userData?.user?.email) continue;
+
+      const renewalDateStr = renewalDate.toLocaleDateString("en-AU", {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+      });
+
+      const emailData = {
+        cardName: (userCard.card?.name ?? userCard.name ?? "Card") as string,
+        bank: (userCard.card?.bank ?? userCard.bank ?? "Bank") as string,
+        annualFee,
+        renewalDate: renewalDateStr,
+        daysRemaining: daysUntilRenewal,
+        appUrl: APP_URL,
+      };
+
+      const email = annualFeeTemplate(emailData);
+      const reminderTypeWithYear = `${annualFeeReminderType}_${renewalYear}`;
+
+      const sendPromise = resend.emails
+        .send({
+          from: FROM_EMAIL,
+          to: userData.user.email,
+          subject: email.subject,
+          html: email.html,
+          text: email.text,
+        })
+        .then(async () => {
+          await supabaseAdmin.from("email_reminders").insert({
+            user_card_id: userCard.id,
+            reminder_type: reminderTypeWithYear,
+            email_to: userData.user!.email!,
+          });
+
+          remindersSent[annualFeeReminderType as keyof typeof remindersSent]++;
+        })
+        .catch((err) => {
+          console.error(`Failed to send ${annualFeeReminderType} reminder:`, err);
         });
 
       promises.push(sendPromise);

--- a/app/src/lib/email/templates.ts
+++ b/app/src/lib/email/templates.ts
@@ -267,3 +267,102 @@ Cancel your card now: ${data.appUrl}/dashboard
     `.trim(),
   };
 }
+
+interface AnnualFeeReminderEmailData {
+  cardName: string;
+  bank: string;
+  annualFee: number;
+  renewalDate: string;
+  daysRemaining: number;
+  appUrl: string;
+}
+
+export function getAnnualFee30DayReminderEmail(data: AnnualFeeReminderEmailData) {
+  return {
+    subject: `💳 ${data.bank} ${data.cardName} annual fee of $${data.annualFee} renews in 30 days`,
+    html: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Annual Fee Reminder</title>
+        </head>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #4edea3 0%, #10b981 100%); padding: 30px; border-radius: 10px; text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #003824; margin: 0; font-size: 24px;">💳 Annual Fee Reminder</h1>
+          </div>
+          <div style="background: #f7fafc; padding: 25px; border-radius: 8px; margin-bottom: 20px;">
+            <h2 style="margin-top: 0; color: #2d3748;">30 Days Until Annual Fee</h2>
+            <p style="font-size: 16px;">Your <strong>${data.bank} ${data.cardName}</strong> annual fee of <strong>$${data.annualFee}</strong> renews on:</p>
+            <p style="font-size: 24px; font-weight: bold; color: #10b981; margin: 15px 0;">${data.renewalDate}</p>
+            <p style="font-size: 14px; color: #4a5568;">You have 30 days to cancel if you don't want to pay it. To cancel, contact ${data.bank} directly or visit your card account online.</p>
+          </div>
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${data.appUrl}/cards" style="display: inline-block; background: linear-gradient(135deg, #4edea3 0%, #10b981 100%); color: #003824; font-weight: bold; text-decoration: none; padding: 14px 28px; border-radius: 25px;">
+              View My Cards →
+            </a>
+          </div>
+          <div style="border-top: 2px solid #e2e8f0; padding-top: 20px; margin-top: 30px; text-align: center; color: #718096; font-size: 14px;">
+            <p>Reward Relay — know when to act on your cards.</p>
+          </div>
+        </body>
+      </html>
+    `,
+    text: `
+💳 Annual Fee Reminder — 30 Days
+
+Your ${data.bank} ${data.cardName} annual fee of $${data.annualFee} renews on: ${data.renewalDate}
+
+You have 30 days to cancel if you don't want to pay it.
+To cancel, contact ${data.bank} directly or visit your card account online.
+
+View your cards: ${data.appUrl}/cards
+    `.trim(),
+  };
+}
+
+export function getAnnualFee14DayReminderEmail(data: AnnualFeeReminderEmailData) {
+  return {
+    subject: `⚠️ ${data.bank} ${data.cardName} annual fee of $${data.annualFee} renews in 14 days`,
+    html: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Annual Fee Reminder</title>
+        </head>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #f6ad55 0%, #ed8936 100%); padding: 30px; border-radius: 10px; text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #7b341e; margin: 0; font-size: 24px;">⚠️ Annual Fee Due in 14 Days</h1>
+          </div>
+          <div style="background: #fffaf0; border: 2px solid #f6ad55; padding: 25px; border-radius: 8px; margin-bottom: 20px;">
+            <h2 style="margin-top: 0; color: #c05621;">14 Days Until Annual Fee</h2>
+            <p style="font-size: 16px;">Your <strong>${data.bank} ${data.cardName}</strong> annual fee of <strong>$${data.annualFee}</strong> renews on:</p>
+            <p style="font-size: 24px; font-weight: bold; color: #dd6b20; margin: 15px 0;">${data.renewalDate}</p>
+            <p style="font-size: 14px; color: #744210;">Act now if you want to cancel before the fee hits. Contact ${data.bank} directly or visit your card account online.</p>
+          </div>
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${data.appUrl}/cards" style="display: inline-block; background: linear-gradient(135deg, #f6ad55 0%, #ed8936 100%); color: #7b341e; font-weight: bold; text-decoration: none; padding: 14px 28px; border-radius: 25px;">
+              View My Cards →
+            </a>
+          </div>
+          <div style="border-top: 2px solid #e2e8f0; padding-top: 20px; margin-top: 30px; text-align: center; color: #718096; font-size: 14px;">
+            <p>Reward Relay — know when to act on your cards.</p>
+          </div>
+        </body>
+      </html>
+    `,
+    text: `
+⚠️ Annual Fee Reminder — 14 Days
+
+Your ${data.bank} ${data.cardName} annual fee of $${data.annualFee} renews on: ${data.renewalDate}
+
+Act now if you want to cancel before the fee hits.
+Contact ${data.bank} directly or visit your card account online.
+
+View your cards: ${data.appUrl}/cards
+    `.trim(),
+  };
+}


### PR DESCRIPTION
Strategic change: protection features (spend deadline alerts, cancellation reminders, annual fee alerts) are now free tier. These are the conversion-driving moments — gating them prevented free users from ever experiencing core value.

## Changes
- **All users get 30/14/7 day reminder cadence** — removed the tier check that restricted 30-day and 14-day cancellation reminders to Pro only (was line 96: `if (!isPro && reminderType !== "7_day") continue`)
- **Annual fee renewal reminders added** — new `annual_fee_30d` and `annual_fee_14d` reminder types fire at 30 and 14 days before card anniversary (calculated from `application_date + 12 months`); deduplication scoped per renewal year so they re-fire each anniversary
- **Dashboard protection widgets already ungated** — confirmed no `ProGate` wrapping bonus trackers, cancel alerts, or spend progress bars
- User preference opt-out flags (`reminder_30d`, `reminder_14d`, `reminder_7d`) preserved — users can still opt out

## Files changed
- `app/src/app/api/reminders/check/route.ts` — tier gate removed, annual fee loop added
- `app/src/lib/email/templates.ts` — `getAnnualFee30DayReminderEmail` and `getAnnualFee14DayReminderEmail` added